### PR TITLE
ATED-3822: Further fixes to view client summary page

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/views/agent/agentSummary/clients.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/agent/agentSummary/clients.scala.html
@@ -12,9 +12,9 @@
 
 @implicitFormInstance = @{ Some(filterClientsForm) }
 
-<span class="screen-reader-text">@screenReaderText</span>
-
 @main_template(title = Messages("client.summary.title", service.toUpperCase), sidebarLinks = if(isUkAgent(agentDetails)) None else Some(_agentSummary_sidebar(agentDetails, service)), delegatedService = Some(service)){
+
+<span class="screen-reader-text">@screenReaderText</span>
 
 <header class="page-header page-header-margin">
   <h1 id="header" class="heading-xlarge">@Messages("client.summary.title", service.toUpperCase)</h1>
@@ -43,7 +43,7 @@
 
 
   <section id="clients-tab" tabindex="-1">
-
+    
 @if(mandates.activeMandates.size >= 15 || isUpdate) {
   <div class="form-group">
     @if(isUpdate) {

--- a/app/uk/gov/hmrc/agentclientmandate/views/agent/agentSummary/pending.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/agent/agentSummary/pending.scala.html
@@ -14,9 +14,9 @@
 <script src='@uk.gov.hmrc.agentclientmandate.controllers.routes.AssetsController.at("javascript/agent-summary.js")'></script>
 }
 
-<span class="screen-reader-text">@screenReaderText</span>
-
 @main_template(title = Messages("client.summary.title", service.toUpperCase), sidebarLinks = if(isUkAgent(agentDetails)) None else Some(_agentSummary_sidebar(agentDetails, service)), scriptElem = Some(pageScripts), delegatedService = Some(service)){
+
+<span class="screen-reader-text">@screenReaderText</span>
 
 <header class="page-header page-header-margin">
   <h1 id="header" class="heading-xlarge">@Messages("client.summary.title", service.toUpperCase)</h1>

--- a/public/javascript/clients.js
+++ b/public/javascript/clients.js
@@ -1,8 +1,7 @@
-var crTab = document.getElementById("clients")
 var prevUrl = document.referrer;
 
 if (prevUrl.includes("summary")) {
-    document.getElementById('clients-tab').focus();
+    document.getElementById("clients-tab").focus();
 }
 
 

--- a/public/javascript/error-summary.js
+++ b/public/javascript/error-summary.js
@@ -1,3 +1,4 @@
 window.onload = function() {
-    document.getElementById("errors").focus();
+    if(document.getElementById("errors"))
+        document.getElementById("errors").focus();
 };

--- a/public/javascript/timeout-dialog.js
+++ b/public/javascript/timeout-dialog.js
@@ -74,7 +74,7 @@ String.prototype.format = function() {
       logout_url: '/sign-out',
       logout_redirect_url: '/',
       restart_on_yes: true,
-      dialog_width: 340,:
+      dialog_width: 340,
       close_on_escape: false,
       background_no_scroll: false
     }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -247,7 +247,7 @@ html.noScroll {
 .ated-tabs li {
     position: relative;
     margin: 0 2px;
-    padding: 20 20px;
+    padding: 20px 20px;
     border: 1px solid #FFF;
     display: inline-block;
     z-index: 0;


### PR DESCRIPTION
Pulled in JS change from ATED-3834. Fixed issue with screen-reader-text div being outside page (?!)