### PR TITLE
ATED-3893: Further fixes to agent appointment confirmation page

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/views/client/collectEmail.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/client/collectEmail.scala.html
@@ -16,18 +16,13 @@
 
   @form(action = routes.CollectEmailController.submit(service, mode)) {
 
-    <div class="form-group">
-
-      @mandateInput(addEmailForm("email"),
-        '_label -> Messages("client.collect-email.email.label"),
-        '_labelClass -> "visuallyhidden",
-        '_showConstraints -> false
-      )
-
-    </div>
+    @mandateInput(addEmailForm("email"),
+      '_label -> Messages("client.collect-email.email.label"),
+      '_labelClass -> "visuallyhidden",
+      '_showConstraints -> false
+    )
 
     <button class="button" id="submit" type="submit">@Messages("continue-button")</button>
-
 
   }
 

--- a/app/uk/gov/hmrc/agentclientmandate/views/client/reviewMandate.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/client/reviewMandate.scala.html
@@ -47,9 +47,9 @@
          </div>
 
          <div class="grid grid-1-6 cya-change">
-           <a href='@routes.CollectEmailController.edit(service)' id="edit-clinet-own-email">
+           <a href='@routes.CollectEmailController.edit(service)' id="edit-client-own-email">
              @Messages("edit-link")
-             <span class="visuallyhidden">@Messages("client.review-agent.email")<</span>
+             <span class="visuallyhidden">@Messages("client.review-agent.own.email")</span>
            </a>
          </div>
        </div>

--- a/conf/messages
+++ b/conf/messages
@@ -209,7 +209,7 @@ agent.client-permission.header = Do you have permission to register on behalf of
 agent.client-permission.error.general.hasPermission = There is a problem with the client permission question
 agent.client-permission.hasPermission.not-selected.error = You must answer the client permission question
 
-agent.client-permission.hasPermission.selected.ated.yes.notice = Your client must complete an <a href="https://www.gov.uk/government/publications/annual-tax-on-enveloped-dwellings-ated-1" data-journey-click="agent-client-mandate:click:ATED-1-link">ATED 1</a>. Once you have registered, send their ATED 1 to HMRC and keep a copy for your records. If you already have an ATED 1 for this client, they do not need to complete another. Form 64-8 does not cover ATED or ATED-related Capital Gains Tax.
+agent.client-permission.hasPermission.selected.ated.yes.notice = Your client must complete an <a href="https://www.gov.uk/government/publications/annual-tax-on-enveloped-dwellings-ated-1" data-journey-click="agent-client-mandate:click:ATED-1-link">ATED 1</a>. Once you have registered, send their ATED 1 to HMRC and keep a copy for your records. If you already have an ATED&nbsp;1 for this client, they do not need to complete another. Form 64-8 does not cover ATED or ATED-related Capital Gains Tax.
 agent.client-permission.hasPermission.selected.ated.no.notice =  	You must have permission from your client before you can continue.
 
 # agent - has client registered before page

--- a/conf/messages
+++ b/conf/messages
@@ -125,7 +125,7 @@ client.agent-confirmation.banner-text = Your request to appoint {0} has been suc
 client.agent-confirmation.banner-confirmation.submitted.date = on {0}
 client.agent-confirmation.notification = Your agent will receive an email notification.
 client.agent-confirmation.header = What happens next
-client.agent-confirmation.sign-in = This authority will remain in place until you change or cancel your agent. You can sign in at any point to view <a href="{0}" id="calling-service" rel="calling-service"data-journey-click="agent-client-mandate:click:sign-in-link">your online service</a>
+client.agent-confirmation.sign-in = This authority will remain in place until you change or cancel your agent. You can sign in at any point to view <a href="{0}" id="calling-service" data-journey-click="agent-client-mandate:click:sign-in-link">your online service</a>
 
 client.agent-confirmation.finish-signout = Sign out
 client.declaration.error.general.agree = There is a problem with the checkbox


### PR DESCRIPTION
Removed duplicate divs
Fixed edit link on CYA page
Removed rel attribute from confirmation page
Add &nbsp; to ATED 1 so it doesn't break across 2 lines