### PR TITLE
DL-2125 Refactor unit tests to not use FakeApp

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/config/AppConfig.scala
@@ -19,15 +19,21 @@ package uk.gov.hmrc.agentclientmandate.config
 import java.util.Base64
 
 import javax.inject.{Inject, Named}
-import play.api.Environment
+import play.api.{Configuration, Environment, Logger}
 import uk.gov.hmrc.agentclientmandate.controllers.auth.ExternalUrls
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.play.config.AssetsConfig
+import uk.gov.hmrc.play.views.html.layouts.{Footer, GTMSnippet, Head, OptimizelySnippet}
 
 import scala.util.Try
 
 class AppConfig @Inject()(
                            val servicesConfig: ServicesConfig,
                            val environment: Environment,
+                           val optimizelySnippet: OptimizelySnippet,
+                           val assetsConfig: AssetsConfig,
+                           val gtmSnippet: GTMSnippet,
+                           val configuration: Configuration,
                            @Named("appName") val appName: String
                          ) extends ExternalUrls with CountryCodes {
 
@@ -97,6 +103,9 @@ class AppConfig @Inject()(
 
     new String(Base64.getDecoder.decode(base64String), "UTF-8").split(",").toList
   }
+
+  lazy val customHeadTemplate = new Head(optimizelySnippet, assetsConfig, gtmSnippet)
+  lazy val customFooterTemplate = new Footer(assetsConfig)
 }
 
 

--- a/app/uk/gov/hmrc/agentclientmandate/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/govuk_wrapper.scala.html
@@ -43,7 +43,7 @@
 }
 
 @head = {
-    @uiLayouts.head(
+    @appConfig.customHeadTemplate(
       linkElem = Some(linkElement),
       headScripts = None)
     <meta name="format-detection" content="telephone=no" />
@@ -84,7 +84,7 @@
 @*afterHeader = {}*@
 
 @bodyEnd = {
-    @uiLayouts.footer(
+    @appConfig.customFooterTemplate(
       analyticsToken = Some(appConfig.analyticsToken),
       analyticsHost = appConfig.analyticsHost,
       ssoUrl = None,

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -41,7 +41,8 @@ private object AppDependencies {
         "org.scalacheck" %% "scalacheck" % "1.14.0" % scope,
         "org.mockito" % "mockito-core" % "2.28.2" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "com.github.tomakehurst" % "wiremock-jre8" % "2.21.0" % "test,it"
+        "com.github.tomakehurst" % "wiremock-jre8" % "2.21.0" % "test,it",
+        "uk.gov.hmrc" %% "bootstrap-play-26" % "0.46.0" % scope classifier "tests"
       )
     }.test
   }

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -52,6 +52,7 @@ trait MicroService {
       retrieveManaged := true,
       evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
       routesGenerator := InjectedRoutesGenerator,
+      Keys.fork                  in Test            := true,
       Keys.fork                  in IntegrationTest :=  false,
       unmanagedSourceDirectories in IntegrationTest :=  (baseDirectory in IntegrationTest)(base => Seq(base / "it")).value,
       testGrouping               in IntegrationTest :=  oneForkedJvmPerTest((definedTests in IntegrationTest).value),

--- a/test/unit/uk/gov/hmrc/agentclientmandate/builders/MockControllerSetup.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/builders/MockControllerSetup.scala
@@ -19,15 +19,23 @@ package unit.uk.gov.hmrc.agentclientmandate.builders
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
-import play.api.{Application, Environment}
+import play.api.mvc.MessagesControllerComponents
+import play.api.{Application, Configuration, Environment}
 import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import uk.gov.hmrc.play.config.{AssetsConfig, GTMConfig, OptimizelyConfig}
+import uk.gov.hmrc.play.views.html.layouts.{Footer, GTMSnippet, Head, OptimizelySnippet}
 
 trait MockControllerSetup {
   self: MockitoSugar =>
 
-  val app: Application
   val mockAppConfig: AppConfig = mock[AppConfig]
+  val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
+  val mockConfig: Configuration = mock[Configuration]
+  val mockEnvironment: Environment = mock[Environment]
+
+  val stubbedMessagesControllerComponents: MessagesControllerComponents = stubMessagesControllerComponents()
 
   when(mockAppConfig.companyAuthHost)
     .thenReturn("")
@@ -54,7 +62,31 @@ trait MockControllerSetup {
         "" +
         "http://localhost:9959/mandate/agent/client-registered-previously/callPage")
   when(mockAppConfig.servicesConfig)
-    .thenReturn(app.injector.instanceOf[ServicesConfig])
+    .thenReturn(mockServicesConfig)
+  when(mockServicesConfig.getString(ArgumentMatchers.eq("microservice.delegated-service-redirect-url.ated")))
+    .thenReturn("http://localhost:9916/ated/account-summary")
   when(mockAppConfig.environment)
-    .thenReturn(app.injector.instanceOf[Environment])
+    .thenReturn(mockEnvironment)
+
+  val mockOptConfig: OptimizelyConfig = mock[OptimizelyConfig]
+  val mockGtmConfig: GTMConfig = mock[GTMConfig]
+  val mockAssetsConfig: AssetsConfig = mock[AssetsConfig]
+
+  when(mockOptConfig.url)
+    .thenReturn(None)
+  when(mockGtmConfig.url)
+    .thenReturn(None)
+  when(mockAssetsConfig.assetsPrefix)
+    .thenReturn("test")
+
+  when(mockAppConfig.configuration)
+    .thenReturn(mockConfig)
+
+  val optimizelySnippet: OptimizelySnippet = new OptimizelySnippet(mockOptConfig)
+  val gtmSnippet: GTMSnippet = new GTMSnippet(mockGtmConfig)
+
+  when(mockAppConfig.customHeadTemplate)
+    .thenReturn(new Head(optimizelySnippet, mockAssetsConfig, gtmSnippet))
+  when(mockAppConfig.customFooterTemplate)
+    .thenReturn(new Footer(mockAssetsConfig))
 }

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnectorSpec.scala
@@ -35,7 +35,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AgentBuilder, AgentBusiness
 
 import scala.concurrent.Future
 
-class AgentClientMandateConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class AgentClientMandateConnectorSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
   val mockDefaultHttpClient: DefaultHttpClient = mock[DefaultHttpClient]
   val mockServicesConfig: ServicesConfig = mock[ServicesConfig]

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AtedSubscriptionFrontendConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AtedSubscriptionFrontendConnectorSpec.scala
@@ -26,6 +26,7 @@ import play.api.mvc.Request
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientmandate.connectors.AtedSubscriptionFrontendConnector
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, PlainContent}
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.filters.frontend.crypto.SessionCookieCrypto
@@ -33,13 +34,19 @@ import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
 import scala.concurrent.Future
 
-class AtedSubscriptionFrontendConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class AtedSubscriptionFrontendConnectorSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
-  val mockDefaultHttpClient = mock[DefaultHttpClient]
-  val mockServicesConfig = mock[ServicesConfig]
-  val mockSessionCookieCrypto = app.injector.instanceOf[SessionCookieCrypto]
+  val mockDefaultHttpClient: DefaultHttpClient = mock[DefaultHttpClient]
+  val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
+  val mockSessionCookieCrypto: SessionCookieCrypto = mock[SessionCookieCrypto]
+  val mockEncWithDec: Encrypter with Decrypter = mock[Encrypter with Decrypter]
 
   override def beforeEach(): Unit = {
+    when(mockSessionCookieCrypto.crypto)
+      .thenReturn(mockEncWithDec)
+    when(mockEncWithDec.encrypt(ArgumentMatchers.any()))
+      .thenReturn(Crypted("test"))
+
     reset(mockDefaultHttpClient)
   }
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/BusinessCustomerConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/BusinessCustomerConnectorSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
 import scala.concurrent.Future
 
-class BusinessCustomerConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class BusinessCustomerConnectorSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
   val testAgentAuthRetrievals = AgentAuthRetrievals(
     "agentRef",

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/BusinessCustomerFrontendConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/BusinessCustomerFrontendConnectorSpec.scala
@@ -26,6 +26,7 @@ import play.api.mvc.Request
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientmandate.connectors.BusinessCustomerFrontendConnector
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter}
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.filters.frontend.crypto.SessionCookieCrypto
@@ -33,13 +34,19 @@ import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
 import scala.concurrent.Future
 
-class BusinessCustomerFrontendConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class BusinessCustomerFrontendConnectorSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
   val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
   val mockDefaultHttpClient: DefaultHttpClient = mock[DefaultHttpClient]
-  val mockSessionCookieCrypto: SessionCookieCrypto = app.injector.instanceOf[SessionCookieCrypto]
+  val mockSessionCookieCrypto: SessionCookieCrypto = mock[SessionCookieCrypto]
+  val mockEncWithDec: Encrypter with Decrypter = mock[Encrypter with Decrypter]
 
   override def beforeEach(): Unit = {
+    when(mockSessionCookieCrypto.crypto)
+      .thenReturn(mockEncWithDec)
+    when(mockEncWithDec.encrypt(ArgumentMatchers.any()))
+      .thenReturn(Crypted("test"))
+
     reset(mockDefaultHttpClient)
   }
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/DelegationConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/DelegationConnectorSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
 import scala.concurrent.Future
 
-class DelegationConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class DelegationConnectorSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
   val mockDefaultHttpClient = mock[DefaultHttpClient]
   val mockServicesConfig = mock[ServicesConfig]

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/ApplicationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/ApplicationControllerSpec.scala
@@ -18,18 +18,19 @@ package unit.uk.gov.hmrc.agentclientmandate.controllers
 
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.mvc.{MessagesControllerComponents, Result}
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientmandate.controllers.ApplicationController
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 import scala.concurrent.Future
 
-class ApplicationControllerSpec extends PlaySpec with GuiceOneServerPerSuite {
+class ApplicationControllerSpec extends PlaySpec  {
   val service = "ATED"
 
   class Setup {
-    val applicationController = new ApplicationController(app.injector.instanceOf[MessagesControllerComponents])
+    val applicationController = new ApplicationController(stubMessagesControllerComponents())
   }
 
   "ApplicationController" must {

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/AgencyDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/AgencyDetailsControllerSpec.scala
@@ -36,7 +36,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AgentBuilder, Authenticated
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AgencyDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class AgencyDetailsControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
    "AgencyDetailsController" should {
 
@@ -70,7 +70,7 @@ class AgencyDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
     val controller = new AgencyDetailsController(
       mockAgentClientMandateService,
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/AgentMissingEmailControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/AgentMissingEmailControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class AgentMissingEmailControllerSpec  extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "AgentMissingEmailControllerSpec" must {
 
@@ -67,13 +67,13 @@ class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSu
         viewEmailAuthorisedAgent() { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Receive email notifications from your clients - GOV.UK")
-          document.getElementById("header").text() must include("Receive email notifications from your clients")
-          document.getElementById("pre-header").text() must include("Manage your ATED service")
-          document.getElementById("info").text() must be(s"We can send you a notification when a client accepts or rejects your requests in the $service service. You can use a group email address and change it later.")
-          document.getElementById("email_field").text() must be("Your email address")
-          document.getElementById("submit_button").text() must be("Continue")
-          document.getElementById("skip_question").text() must be("Enter my email at a later date")
+          document.title() must be("agent.missing-email.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.missing-email.header")
+          document.getElementById("pre-header").text() must include("ated.screen-reader.section agent.edit-mandate-details.pre-header")
+          document.getElementById("info").text() must be("agent.missing-email.text")
+          document.getElementById("email_field").text() must be("agent.missing-email.email_address")
+          document.getElementById("submit_button").text() must be("continue-button")
+          document.getElementById("skip_question").text() must be("agent.missing-email.trapdoor")
         }
       }
     }
@@ -84,8 +84,8 @@ class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSu
         submitEmailAuthorisedAgent(fakeRequest, isValidEmail = true) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the question")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.useEmailAddress")
+          document.getElementsByClass("error-notification").text() must include("agent.missing-email.must_answer")
         }
       }
 
@@ -94,8 +94,8 @@ class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSu
         submitEmailAuthorisedAgent(fakeRequest, isValidEmail = true) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter the email address you want to use for this client")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.empty")
         }
       }
 
@@ -105,8 +105,8 @@ class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSu
         submitEmailAuthorisedAgent(fakeRequest, isValidEmail = false) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("The email address you want to use for this client must be 241 characters or less")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.too.long")
         }
       }
       "invalid email is passed" in new Setup {
@@ -114,8 +114,8 @@ class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSu
         submitEmailAuthorisedAgent(fakeRequest, isValidEmail = false) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter an email address in the correct format, like name@example.com")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.invalid")
         }
       }
     }
@@ -149,7 +149,7 @@ class AgentMissingEmailControllerSpec  extends PlaySpec with GuiceOneServerPerSu
   class Setup {
     val controller = new AgentMissingEmailController(
       mockAgentClientMandateService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/AgentSummaryControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/AgentSummaryControllerSpec.scala
@@ -42,7 +42,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AgentBuilder, Authenticated
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class AgentSummaryControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
 
   "AgentClientSummaryController" must {
@@ -54,9 +54,9 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("ATED clients - GOV.UK")
+          document.title() must be("client.summary.title - GOV.UK")
           document.getElementById("ur-panel") must not be null
-          document.getElementsByClass("banner-panel__close").text must be("No thanks")
+          document.getElementsByClass("banner-panel__close").text must be("urbanner.message.reject")
         }
       }
     }
@@ -68,9 +68,9 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("ATED clients - GOV.UK")
-          document.getElementById("header").text must be("ATED clients")
-          document.getElementById("add-client-btn").text() must be("Add a client")
+          document.title() must be("client.summary.title - GOV.UK")
+          document.getElementById("header").text must be("client.summary.title")
+          document.getElementById("add-client-btn").text() must be("client.summary.add-client")
           document.getElementById("add-client-link") must be(null)
           document.getElementById("view-pending-clients") must be(null)
           document.getElementById("view-clients") must be(null)
@@ -83,13 +83,13 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("ATED clients - GOV.UK")
-          document.getElementById("header").text must be("ATED clients")
-          document.getElementById("add-client-link").text() must be("Add a client")
+          document.title() must be("client.summary.title - GOV.UK")
+          document.getElementById("header").text must be("client.summary.title")
+          document.getElementById("add-client-link").text() must be("client.summary.add-client")
           document.getElementById("filter-clients") must be(null)
           document.getElementById("displayName_field") must be(null)
           document.getElementById("add-client-btn") must be(null)
-          document.getElementById("view-pending-clients").attr("href") must be("/mandate/agent/summary?tabName=pending-clients")
+          document.getElementById("view-pending-clients").attr("href") must be("/agent/summary?tabName=pending-clients")
           document.getElementById("view-clients") must be(null)
         }
       }
@@ -100,13 +100,13 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("ATED clients - GOV.UK")
-          document.getElementById("header").text must be("ATED clients")
-          document.getElementById("add-client-link").text() must be("Add a client")
-          document.getElementById("filter-clients").text() must be("Filter clients")
-          document.getElementById("displayName_field").text() must be("Display name (optional)")
+          document.title() must be("client.summary.title - GOV.UK")
+          document.getElementById("header").text must be("client.summary.title")
+          document.getElementById("add-client-link").text() must be("client.summary.add-client")
+          document.getElementById("filter-clients").text() must be("client.summary.filter-clients")
+          document.getElementById("displayName_field").text() must be("client.summary.filter-display_name")
           document.getElementById("add-client-btn") must be(null)
-          document.getElementById("view-pending-clients").attr("href") must be("/mandate/agent/summary?tabName=pending-clients")
+          document.getElementById("view-pending-clients").attr("href") must be("/agent/summary?tabName=pending-clients")
           document.getElementById("view-clients") must be(null)
         }
       }
@@ -120,11 +120,11 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("ATED clients - GOV.UK")
-          document.getElementById("header").text must be("ATED clients")
-          document.getElementById("add-client-link").text() must be("Add a client")
+          document.title() must be("client.summary.title - GOV.UK")
+          document.getElementById("header").text must be("client.summary.title")
+          document.getElementById("add-client-link").text() must be("client.summary.add-client")
           document.getElementById("view-pending-clients") must be(null)
-          document.getElementById("view-clients").attr("href") must be("/mandate/agent/summary")
+          document.getElementById("view-clients").attr("href") must be("/agent/summary")
         }
       }
     }
@@ -137,9 +137,9 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("ATED clients - GOV.UK")
-          document.getElementById("header").text must be("ATED clients")
-          document.getElementById("add-client-link").text() must be("Add a client")
+          document.title() must be("client.summary.title - GOV.UK")
+          document.getElementById("header").text must be("client.summary.title")
+          document.getElementById("add-client-link").text() must be("client.summary.add-client")
           document.getElementById("view-pending-clients") must be(null)
           document.getElementById("view-clients") must be(null)
         }
@@ -202,7 +202,7 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         activateClientByAuthorisedAgent(controller) { result =>
 
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/agent/summary")
+          redirectLocation(result).get must include("/agent/summary")
         }
       }
 
@@ -270,7 +270,7 @@ class AgentSummaryControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
       mockAgentClientMandateService,
       mockDataCacheService,
       mockDelegationConnector,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/ClientDisplayNameControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/ClientDisplayNameControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class ClientDisplayNameControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "ClientDisplayNameController" must {
 
@@ -70,8 +70,8 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         viewClientDisplayNameAuthorisedAgent() { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What display name do you want to use for this client? - GOV.UK")
-          document.getElementById("header").text() must include("What display name do you want to use for this client?")
+          document.title() must be("agent.client-display-name.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.client-display-name.header")
         }
       }
 
@@ -79,7 +79,7 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         viewClientDisplayNameAuthorisedAgent(Some(ClientDisplayName("client display name")), Some("/api/anywhere")) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What display name do you want to use for this client? - GOV.UK")
+          document.title() must be("agent.client-display-name.title - GOV.UK")
           document.getElementById("clientDisplayName").`val`() must be("client display name")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[ClientDisplayName](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -95,8 +95,8 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         editClientDisplayNameAuthorisedAgent() { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What display name do you want to use for this client? - GOV.UK")
-          document.getElementById("header").text() must include("What display name do you want to use for this client?")
+          document.title() must be("agent.client-display-name.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.client-display-name.header")
         }
       }
 
@@ -104,7 +104,7 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         editClientDisplayNameAuthorisedAgent(Some(ClientDisplayName("client display name")), Some("/api/anywhere")) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What display name do you want to use for this client? - GOV.UK")
+          document.title() must be("agent.client-display-name.title - GOV.UK")
           document.getElementById("clientDisplayName").`val`() must be("client display name")
         }
       }
@@ -121,7 +121,7 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("clientDisplayName" -> "client display name")
         submitClientDisplayNameAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/overseas-client-question"))
+          redirectLocation(result) must be(Some("/agent/overseas-client-question"))
           verify(mockDataCacheService, times(1)).cacheFormData[ClientDisplayName](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
       }
@@ -149,8 +149,8 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         submitClientDisplayNameAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the client display name question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the client display name question")
+          document.getElementsByClass("error-list").text() must include("agent.client-display-name.error.general.clientDisplayName")
+          document.getElementsByClass("error-notification").text() must include("agent.client-display-name.error.not-selected")
         }
       }
 
@@ -160,8 +160,8 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
         submitClientDisplayNameAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the client display name question")
-          document.getElementsByClass("error-notification").text() must include("A client display name cannot be more than 99 characters")
+          document.getElementsByClass("error-list").text() must include("agent.client-display-name.error.general.clientDisplayName")
+          document.getElementsByClass("error-notification").text() must include("agent.client-display-name.error.length")
         }
       }
     }
@@ -191,7 +191,7 @@ class ClientDisplayNameControllerSpec extends PlaySpec with GuiceOneServerPerSui
   class Setup {
     val controller = new ClientDisplayNameController(
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/ClientPermissionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/ClientPermissionControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuite with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
+class ClientPermissionControllerSpec extends PlaySpec  with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
 
   "ClientPermissionController" must {
 
@@ -68,16 +68,16 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         viewWithAuthorisedAgent(service, ControllerPageIdConstants.paySAQuestionControllerId) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Do you have permission to register on behalf of your client? - GOV.UK")
-          document.getElementById("header").text() must include("Do you have permission to register on behalf of your client?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("hasPermission_legend").text() must be("Do you have permission to register on behalf of your client?")
+          document.title() must be("agent.client-permission.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.client-permission.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("hasPermission_legend").text() must be("agent.client-permission.header")
           document.getElementById("permission-text").text() must
-            startWith("Your client must complete an ATED 1. Once you have registered, send their ATED 1 to HMRC and keep a copy for your records.")
-          document.getElementById("continue").text() must be("Continue")
+            startWith("agent.client-permission.hasPermission.selected.ated.yes.notice")
+          document.getElementById("continue").text() must be("continue-button")
 
-          document.getElementById("backLinkHref").text() must be("Back")
-          document.getElementById("backLinkHref").attr("href") must be("/mandate/agent/paySA-question")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
+          document.getElementById("backLinkHref").attr("href") must be("/agent/paySA-question")
         }
       }
 
@@ -85,17 +85,17 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         viewWithAuthorisedAgentWithSomeData(service, ControllerPageIdConstants.paySAQuestionControllerId) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Do you have permission to register on behalf of your client? - GOV.UK")
-          document.getElementById("header").text() must include("Do you have permission to register on behalf of your client?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("hasPermission_legend").text() must be("Do you have permission to register on behalf of your client?")
+          document.title() must be("agent.client-permission.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.client-permission.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("hasPermission_legend").text() must be("agent.client-permission.header")
           document.getElementById("permission-text").text() must
-            startWith("Your client must complete an ATED 1. Once you have registered, send their ATED 1 to HMRC and keep a copy for your records.")
+            startWith("agent.client-permission.hasPermission.selected.ated.yes.notice")
           document.getElementById("hasPermission-true").attr("checked") must be("checked")
-          document.getElementById("continue").text() must be("Continue")
+          document.getElementById("continue").text() must be("continue-button")
 
-          document.getElementById("backLinkHref").text() must be("Back")
-          document.getElementById("backLinkHref").attr("href") must be("/mandate/agent/paySA-question")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
+          document.getElementById("backLinkHref").attr("href") must be("/agent/paySA-question")
         }
       }
 
@@ -103,21 +103,21 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         viewWithAuthorisedAgent(service, ControllerPageIdConstants.nrlQuestionControllerId) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Do you have permission to register on behalf of your client? - GOV.UK")
-          document.getElementById("header").text() must include("Do you have permission to register on behalf of your client?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("hasPermission_legend").text() must be("Do you have permission to register on behalf of your client?")
-          document.getElementById("continue").text() must be("Continue")
+          document.title() must be("agent.client-permission.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.client-permission.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("hasPermission_legend").text() must be("agent.client-permission.header")
+          document.getElementById("continue").text() must be("continue-button")
 
-          document.getElementById("backLinkHref").text() must be("Back")
-          document.getElementById("backLinkHref").attr("href") must be("/mandate/agent/nrl-question")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
+          document.getElementById("backLinkHref").attr("href") must be("/agent/nrl-question")
         }
       }
       "agent requests(GET) for 'client permission' view for other service - it doesn't clear session cache for ated-subscription" in new Setup {
         viewWithAuthorisedAgent(serviceUsed = "otherService", "") { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Do you have permission to register on behalf of your client? - GOV.UK")
+          document.title() must be("agent.client-permission.title - GOV.UK")
         }
       }
     }
@@ -127,7 +127,7 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("hasPermission" -> "true")
         submitWithAuthorisedAgent("", fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/agent/client-registered-previously")
+          redirectLocation(result).get must include("/agent/client-registered-previously")
         }
       }
     }
@@ -137,7 +137,7 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("hasPermission" -> "false")
         submitWithAuthorisedAgent("", fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(s"/mandate/agent/summary?tabName=ATED"))
+          redirectLocation(result) must be(Some(s"/agent/summary?tabName=ATED"))
         }
       }
     }
@@ -148,8 +148,8 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         submitWithAuthorisedAgent("", fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the client permission question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the client permission question")
+          document.getElementsByClass("error-list").text() must include("agent.client-permission.error.general.hasPermission")
+          document.getElementsByClass("error-notification").text() must include("agent.client-permission.hasPermission.not-selected.error")
         }
       }
     }
@@ -167,7 +167,7 @@ class ClientPermissionControllerSpec extends PlaySpec with GuiceOneServerPerSuit
       mockBusinessCustomerConnector,
       mockAtedSubscriptionConnector,
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/CollectAgentEmailControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/CollectAgentEmailControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class CollectAgentEmailControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "CollectAgentEmailController" must {
 
@@ -70,7 +70,7 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         viewEmailAuthorisedAgent(Some(agentEmail)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What email address do you want to use for this client? - GOV.UK")
+          document.title() must be("agent.enter-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("aa@aa.com")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[AgentEmail](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -80,7 +80,7 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         editEmailAuthorisedAgent(Some(agentEmail)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What email address do you want to use for this client? - GOV.UK")
+          document.title() must be("agent.enter-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("aa@aa.com")
         }
       }
@@ -92,13 +92,13 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         viewEmailAuthorisedAgent(None, Some("/api/anywhere")) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What email address do you want to use for this client? - GOV.UK")
-          document.getElementById("header").text() must include("What email address do you want to use for this client?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("info").text() must include(s"We will use this email address to send you notifications about this client.")
-          document.getElementById("email_field").text() must be("What email address do you want to use for this client?")
+          document.title() must be("agent.enter-email.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.enter-email.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("info").text() must include(s"agent.enter-email.info.text")
+          document.getElementById("email_field").text() must be("agent.enter-email.field.email.label")
           document.getElementById("email").`val`() must be("")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[AgentEmail](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
       }
@@ -107,13 +107,13 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         editEmailAuthorisedAgent(None, Some("/api/anywhere")) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What email address do you want to use for this client? - GOV.UK")
-          document.getElementById("header").text() must include("What email address do you want to use for this client?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("info").text() must include(s"We will use this email address to send you notifications about this client.")
-          document.getElementById("email_field").text() must be("What email address do you want to use for this client?")
+          document.title() must be("agent.enter-email.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.enter-email.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("info").text() must include(s"agent.enter-email.info.text")
+          document.getElementById("email_field").text() must be("agent.enter-email.field.email.label")
           document.getElementById("email").`val`() must be("")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -129,7 +129,7 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         addClientAuthorisedAgent(Some(clientMandatDisplay)){ result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What email address do you want to use for this client? - GOV.UK")
+          document.title() must be("agent.enter-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("agent@mail.com")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[ClientMandateDisplayDetails](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -139,7 +139,7 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         addClientAuthorisedAgent(None) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What email address do you want to use for this client? - GOV.UK")
+          document.title() must be("agent.enter-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[ClientMandateDisplayDetails](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -153,7 +153,7 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("email" -> "aa@aa.com")
         submitEmailAuthorisedAgent(fakeRequest, isValidEmail = true) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/client-display-name"))
+          redirectLocation(result) must be(Some("/agent/client-display-name"))
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[AgentEmail](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(1)).cacheFormData[AgentEmail](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -184,8 +184,8 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         submitEmailAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter the email address you want to use for this client")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.empty")
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[AgentEmail](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[AgentEmail](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -197,8 +197,8 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         submitEmailAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter an email address in the correct format, like name@example.com")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.invalid")
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[AgentEmail](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[AgentEmail](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -209,9 +209,9 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
         submitEmailAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
+          document.getElementsByClass("error-list").text() must include("agent.enter-email.error.general.email")
           document.getElementsByClass("error-notification").text() must
-            include("The email address you want to use for this client must be 241 characters or less")
+            include("client.email.error.email.too.long")
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[AgentEmail](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[AgentEmail](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -245,7 +245,7 @@ class CollectAgentEmailControllerSpec extends PlaySpec with GuiceOneServerPerSui
 
   class Setup {
     val controller = new CollectAgentEmailController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       mockDataCacheService,
       implicitly,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/EditMandateDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/EditMandateDetailsControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class EditMandateDetailsControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "EditMandateControllerSpec" must {
 
@@ -50,13 +50,13 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
         viewWithAuthorisedAgent(Some(mandate)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Edit test client4 - GOV.UK")
-          document.getElementById("header").text() must include("Edit test client4")
-          document.getElementById("pre-header").text() must include("Manage your ATED service")
-          document.getElementById("sub-heading").text() must be("Unique authorisation number AS123456")
-          document.getElementById("displayName_field").text() must include("Display name")
-          document.getElementById("displayName_hint").text() must include("This does not change the official company name.")
-          document.getElementById("submit").text() must be("Save changes")
+          document.title() must be("agent.edit-mandate-details.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.edit-mandate-details.header")
+          document.getElementById("pre-header").text() must include("ated.screen-reader.section agent.edit-mandate-details.pre-header")
+          document.getElementById("sub-heading").text() must be("agent.edit-mandate-details.sub-heading")
+          document.getElementById("displayName_field").text() must include("agent.edit-mandate-details.displayName agent.edit-mandate-details.hint")
+          document.getElementById("displayName_hint").text() must include("agent.edit-mandate-details.hint")
+          document.getElementById("submit").text() must be("agent.edit-mandate-details.submit")
         }
       }
     }
@@ -76,9 +76,9 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
         submitEditMandateDetails(fakeRequest, emailValid = false, getMandate = Some(mandate)) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email question")
+          document.getElementsByClass("error-list").text() must include("agent.edit-client.error.general.email")
           document.getElementsByClass("error-notification").text() must
-            include("You must answer the client display name question Enter the email address you want to use for this client")
+            include("agent.edit-client.error.dispName client.email.error.email.empty")
         }
       }
 
@@ -87,8 +87,8 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
         submitEditMandateDetails(fakeRequest, emailValid = false, getMandate = Some(mandate), editMandate = Some(mandate)) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email question")
-          document.getElementsByClass("error-notification").text() must include("Enter an email address in the correct format, like name@example.com")
+          document.getElementsByClass("error-list").text() must include("agent.edit-client.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.invalid")
         }
       }
 
@@ -97,9 +97,9 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
         submitEditMandateDetails(fakeRequest, emailValid = false, getMandate = Some(mandate), editMandate = Some(mandate)) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email question")
+          document.getElementsByClass("error-list").text() must include("agent.edit-client.error.general.email")
           document.getElementsByClass("error-notification").text() must
-            include("The email address you want to use for this client must be 241 characters or less")
+            include("client.email.error.email.too.long")
         }
       }
     }
@@ -129,7 +129,7 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("displayName" -> "disp-name", "email" -> "aa@mail.com")
         submitEditMandateDetails(fakeRequest, emailValid = true, getMandate = Some(mandate), editMandate = Some(mandate)) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(s"/mandate/agent/summary"))
+          redirectLocation(result) must be(Some(s"/agent/summary"))
         }
       }
     }
@@ -139,7 +139,7 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("displayName" -> "disp-name", "email" -> "aa@mail.com")
         submitEditMandateDetails(fakeRequest, emailValid = true, getMandate = Some(mandate)) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(s"/mandate/agent/edit-client/AS123456"))
+          redirectLocation(result) must be(Some(s"/agent/edit-client/AS123456"))
         }
       }
     }
@@ -181,7 +181,7 @@ class EditMandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSu
 
   class Setup {
     val controller = new EditMandateDetailsController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAcmService,
       implicitly,
       mockAppConfig,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/HasClientRegisteredBeforeControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/HasClientRegisteredBeforeControllerSpec.scala
@@ -42,7 +42,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServerPerSuite with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
+class HasClientRegisteredBeforeControllerSpec extends PlaySpec  with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
 
   "HasClientRegisteredBeforeController" must {
 
@@ -68,7 +68,7 @@ class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServ
         viewWithAuthorisedAgent(service, ControllerPageIdConstants.paySAQuestionControllerId, Some(PrevRegistered(Some(true)))) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must include("Has your client previously had an agent who used the ATED online service to submit returns on their behalf?")
+          document.title() must include("agent.client-prev-registered.title - GOV.UK")
         }
       }
 
@@ -76,7 +76,7 @@ class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServ
         viewWithAuthorisedAgent(service, ControllerPageIdConstants.paySAQuestionControllerId) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must include("Has your client previously had an agent who used the ATED online service to submit returns on their behalf?")
+          document.title() must include("agent.client-prev-registered.title - GOV.UK")
         }
       }
     }
@@ -86,7 +86,7 @@ class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServ
         viewWithAuthorisedAgent("any", ControllerPageIdConstants.paySAQuestionControllerId, Some(PrevRegistered(Some(true)))) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must include("Has your client previously had an agent who used the ATED online service to submit returns on their behalf?")
+          document.title() must include("agent.client-prev-registered.title - GOV.UK")
         }
       }
     }
@@ -96,7 +96,7 @@ class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServ
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("prevRegistered" -> "true")
         submitWithAuthorisedAgent("callPage", fakeRequest, Some(PrevRegistered(Some(true)))) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/agent/search-previous/callPage")
+          redirectLocation(result).get must include("/agent/search-previous/callPage")
         }
       }
     }
@@ -118,8 +118,8 @@ class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServ
         submitWithAuthorisedAgent("callPage", fakeRequest, Some(PrevRegistered(Some(true)))) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the previously had an agent question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the previously had an agent question")
+          document.getElementsByClass("error-list").text() must include("agent.client-permission.error.general.prevRegistered")
+          document.getElementsByClass("error-notification").text() must include("agent.client-prev-registered.not-selected.field-error")
         }
       }
     }
@@ -136,7 +136,7 @@ class HasClientRegisteredBeforeControllerSpec extends PlaySpec with GuiceOneServ
 
   class Setup {
     val controller = new HasClientRegisteredBeforeController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockDataCacheService,
       mockBusinessCustomerConnector,
       mockAtedSubscriptionConnector,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/MandateDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/MandateDetailsControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class MandateDetailsControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "MandateDetailsController" must {
 
@@ -58,14 +58,14 @@ class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
         viewWithAuthorisedAgent(ControllerPageIdConstants.paySAQuestionControllerId) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Check your client’s details are correct - GOV.UK")
-          document.getElementById("pre-header").text must be("This section is: Add a client")
-          document.getElementById("header").text must be("Check your client’s details are correct")
-          document.getElementById("email-address-label").text must be("Your email address")
-          document.getElementById("submit").text must be("Confirm and add client")
+          document.title() must be("agent.check-client-details.header - GOV.UK")
+          document.getElementById("pre-header").text must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("header").text must be("agent.check-client-details.header")
+          document.getElementById("email-address-label").text must be("agent.check-client-details.your-email")
+          document.getElementById("submit").text must be("agent.check-client-details.confirm")
 
-          document.getElementById("backLinkHref").text() must be("Back")
-          document.getElementById("backLinkHref").attr("href") must be("/mandate/agent/paySA-question")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
+          document.getElementById("backLinkHref").attr("href") must be("/agent/paySA-question")
         }
       }
 
@@ -81,14 +81,14 @@ class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
         viewWithAuthorisedAgent(ControllerPageIdConstants.overseasClientQuestionControllerId) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Check your client’s details are correct - GOV.UK")
-          document.getElementById("pre-header").text must be("This section is: Add a client")
-          document.getElementById("header").text must be("Check your client’s details are correct")
-          document.getElementById("email-address-label").text must be("Your email address")
-          document.getElementById("submit").text must be("Confirm and add client")
+          document.title() must be("agent.check-client-details.header - GOV.UK")
+          document.getElementById("pre-header").text must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("header").text must be("agent.check-client-details.header")
+          document.getElementById("email-address-label").text must be("agent.check-client-details.your-email")
+          document.getElementById("submit").text must be("agent.check-client-details.confirm")
 
-          document.getElementById("backLinkHref").text() must be("Back")
-          document.getElementById("backLinkHref").attr("href") must be("/mandate/agent/overseas-client-question")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
+          document.getElementById("backLinkHref").attr("href") must be("/agent/overseas-client-question")
         }
       }
     }
@@ -106,7 +106,7 @@ class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
           .thenReturn(Future.successful("callingPage"))
         viewWithAuthorisedAgent("") { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(s"/mandate/agent/add-client"))
+          redirectLocation(result) must be(Some(s"/agent/add-client"))
         }
       }
     }
@@ -123,7 +123,7 @@ class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
           .thenReturn(Future.successful("callingPage"))
         viewWithAuthorisedAgent("") { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(s"/mandate/agent/client-display-name"))
+          redirectLocation(result) must be(Some(s"/agent/client-display-name"))
         }
       }
     }
@@ -142,7 +142,7 @@ class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
       "form is submitted" in new Setup {
         submitWithAuthorisedAgent { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(s"/mandate/agent/unique-reference"))
+          redirectLocation(result) must be(Some(s"/agent/unique-reference"))
         }
       }
     }
@@ -157,7 +157,7 @@ class MandateDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite 
 
   class Setup {
     val controller = new MandateDetailsController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockDataCacheService,
       mockMandateService,
       implicitly,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/NRLQuestionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/NRLQuestionControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
+class NRLQuestionControllerSpec extends PlaySpec  with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
 
   "NRLQuestionController" must {
 
@@ -67,11 +67,11 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         viewWithAuthorisedAgent { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Is your client a non-resident landlord? - GOV.UK")
-          document.getElementById("header").text() must include("Is your client a non-resident landlord?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("nrl_legend").text() must be("Is your client a non-resident landlord?")
-          document.getElementById("submit").text() must be("Continue")
+          document.title() must be("agent.nrl-question.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.nrl-question.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("nrl_legend").text() must be("agent.nrl-question.header")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -79,12 +79,12 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         viewWithAuthorisedAgentWithSomeData { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Is your client a non-resident landlord? - GOV.UK")
-          document.getElementById("header").text() must include("Is your client a non-resident landlord?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("nrl_legend").text() must be("Is your client a non-resident landlord?")
+          document.title() must be("agent.nrl-question.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.nrl-question.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("nrl_legend").text() must be("agent.nrl-question.header")
           document.getElementById("nrl-true").attr("checked") must be("checked")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -95,7 +95,7 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("nrl" -> "true")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include(s"/mandate/agent/paySA-question")
+          redirectLocation(result).get must include(s"/agent/paySA-question")
         }
       }
     }
@@ -105,7 +105,7 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("nrl" -> "false")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include(s"/mandate/agent/client-permission/nrl")
+          redirectLocation(result).get must include(s"/agent/client-permission/nrl")
         }
       }
     }
@@ -116,8 +116,8 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the non-resident landlord question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the non-resident landlord question")
+          document.getElementsByClass("error-list").text() must include("agent.nrl-question.error.general.nrl")
+          document.getElementsByClass("error-notification").text() must include("agent.nrl-question.nrl.not-selected.error")
         }
       }
     }
@@ -133,7 +133,7 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
   class Setup {
     val controller = new NRLQuestionController(
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/OverseasClientQuestionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/OverseasClientQuestionControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class OverseasClientQuestionControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "OverseasClientQuestionController" must {
 
@@ -72,10 +72,10 @@ class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerP
         viewWithAuthorisedAgent { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Does your client have an overseas company without a UK Unique Taxpayer Reference? - GOV.UK")
-          document.getElementById("header").text() must include("Does your client have an overseas company without a UK Unique Taxpayer Reference?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("submit").text() must be("Continue")
+          document.title() must be("agent.overseas-client-question.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.overseas-client-question.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -83,11 +83,11 @@ class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerP
         viewWithAuthorisedAgentWithSomeData { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Does your client have an overseas company without a UK Unique Taxpayer Reference? - GOV.UK")
-          document.getElementById("header").text() must include("Does your client have an overseas company without a UK Unique Taxpayer Reference?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
+          document.title() must be("agent.overseas-client-question.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.overseas-client-question.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
           document.getElementById("isOverseas-true").attr("checked") must be("checked")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -98,7 +98,7 @@ class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerP
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("isOverseas" -> "true")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/agent/nrl-question")
+          redirectLocation(result).get must include("/agent/nrl-question")
         }
       }
     }
@@ -107,7 +107,7 @@ class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerP
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("isOverseas" -> "false")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include(s"/mandate/agent/details/overseas")
+          redirectLocation(result).get must include(s"/agent/details/overseas")
         }
       }
     }
@@ -118,8 +118,8 @@ class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerP
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the overseas client question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the overseas client question")
+          document.getElementsByClass("error-list").text() must include("agent.overseas-client-question.error.general.isOverseas")
+          document.getElementsByClass("error-notification").text() must include("agent.overseas-client-question.error.isOverseas")
         }
       }
     }
@@ -136,7 +136,7 @@ class OverseasClientQuestionControllerSpec extends PlaySpec with GuiceOneServerP
   class Setup {
     val controller = new OverseasClientQuestionController(
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/PaySAQuestionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/PaySAQuestionControllerSpec.scala
@@ -37,7 +37,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
+class PaySAQuestionControllerSpec extends PlaySpec  with BeforeAndAfterEach with MockitoSugar with MockControllerSetup {
 
   "PaySAQuestionController" must {
 
@@ -64,11 +64,11 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedAgent { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Does your client pay tax in the UK through Self Assessment? - GOV.UK")
-          document.getElementById("header").text() must include("Does your client pay tax in the UK through Self Assessment?")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("paySA_legend").text() must be("Does your client pay tax in the UK through Self Assessment?")
-          document.getElementById("submit").text() must be("Continue")
+          document.title() must be("agent.paySA-question.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.paySA-question.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("paySA_legend").text() must be("agent.paySA-question.header")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
     }
@@ -78,7 +78,7 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("paySA" -> "true")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include(s"/mandate/agent/details/paySA")
+          redirectLocation(result).get must include(s"/agent/details/paySA")
         }
       }
     }
@@ -88,7 +88,7 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("paySA" -> "false")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include(s"/mandate/agent/client-permission/paySA")
+          redirectLocation(result).get must include(s"/agent/client-permission/paySA")
         }
       }
     }
@@ -99,8 +99,8 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the do you pay Self Assessment question")
-          document.getElementsByClass("error-notification").text() must include("You must answer the Self Assessment question")
+          document.getElementsByClass("error-list").text() must include("agent.paySA-question.error.general.paySA")
+          document.getElementsByClass("error-notification").text() must include("agent.paySA-question.paySA.not-selected.error")
         }
       }
     }
@@ -117,7 +117,7 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       mockAuthConnector,
       implicitly,
       mockAppConfig,
-      app.injector.instanceOf[MessagesControllerComponents]
+      stubbedMessagesControllerComponents
     )
 
     def viewWithUnAuthenticatedAgent(test: Future[Result] => Any) {

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/PreviousMandateRefControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/PreviousMandateRefControllerSpec.scala
@@ -42,7 +42,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PreviousMandateRefControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class PreviousMandateRefControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "PreviousMandateRefController" must {
 
@@ -83,10 +83,10 @@ class PreviousMandateRefControllerSpec extends PlaySpec with GuiceOneServerPerSu
         viewWithAuthorisedAgent(Some(cached)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is the previous unique authorisation number for the client? - GOV.UK")
-          document.getElementById("header").text() must include("What is the previous unique authorisation number for the client?")
+          document.title() must be("agent.search-previous-mandate.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.search-previous-mandate.header")
           document.getElementById("mandateRef").`val`() must be("ABC123")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -131,8 +131,8 @@ class PreviousMandateRefControllerSpec extends PlaySpec with GuiceOneServerPerSu
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("You must answer unique authorisation number question")
-          document.getElementsByClass("error-notification").text() must include("You must answer unique authorisation number question")
+          document.getElementsByClass("error-list").text() must include("agent.search-previous-mandate.error.mandateRef")
+          document.getElementsByClass("error-notification").text() must include("client.search-mandate.error.mandateRef")
           verify(mockMandateService, times(0)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -144,8 +144,8 @@ class PreviousMandateRefControllerSpec extends PlaySpec with GuiceOneServerPerSu
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("You must answer unique authorisation number question")
-          document.getElementsByClass("error-notification").text() must include("A unique authorisation number cannot be more than 8 characters")
+          document.getElementsByClass("error-list").text() must include("agent.search-previous-mandate.error.mandateRef")
+          document.getElementsByClass("error-notification").text() must include("client.search-mandate.error.mandateRef")
           verify(mockMandateService, times(0)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -157,9 +157,9 @@ class PreviousMandateRefControllerSpec extends PlaySpec with GuiceOneServerPerSu
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("You must answer unique authorisation number question")
+          document.getElementsByClass("error-list").text() must include("agent.search-previous-mandate.error.mandateRef")
           document.getElementsByClass("error-notification").text() must
-            include("The unique authorisation number you entered cannot be found. Check the number, or enter a different number.")
+            include("client.search-mandate.error.mandateRef.not-found-by-mandate-service")
           verify(mockMandateService, times(1)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -216,7 +216,7 @@ class PreviousMandateRefControllerSpec extends PlaySpec with GuiceOneServerPerSu
 
   class Setup {
     val controller = new PreviousMandateRefController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       mockDataCacheService,
       mockMandateService,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/RejectClientControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/RejectClientControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class RejectClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class RejectClientControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "RejectClientController" must {
 
@@ -73,8 +73,8 @@ class RejectClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         viewWithAuthorisedAgent { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Are you sure you want to reject the request from this client? - GOV.UK")
-          document.getElementById("heading").text() must include("Are you sure you want to reject the request from ACME Limited?")
+          document.title() must be("agent.reject-client.title - GOV.UK")
+          document.getElementById("heading").text() must include("agent.reject-client.header")
         }
       }
     }
@@ -87,8 +87,8 @@ class RejectClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with client reject question")
-          document.getElementsByClass("error-notification").text() must include("The client reject question must be answered")
+          document.getElementsByClass("error-list").text() must include("yes-no.error.general.yesNo")
+          document.getElementsByClass("error-notification").text() must include("yes-no.error.mandatory.clientReject")
         }
       }
     }
@@ -140,7 +140,7 @@ class RejectClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         confirmationWithAuthorisedAgent { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must include("You have rejected this client on")
+          document.title() must include("agent.reject-client-confirmation.title")
         }
       }
     }
@@ -163,7 +163,7 @@ class RejectClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
   class Setup {
     val controller = new RejectClientController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAgentClientMandateService,
       implicitly,
       mockAppConfig,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/RemoveClientControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/RemoveClientControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class RemoveClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class RemoveClientControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   val mockAgentClientMandateService: AgentClientMandateService = mock[AgentClientMandateService]
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
@@ -59,7 +59,7 @@ class RemoveClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
 
   class Setup {
     val controller = new RemoveClientController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAgentClientMandateService,
       implicitly,
       mockAppConfig,
@@ -141,11 +141,11 @@ class RemoveClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
       viewWithAuthorisedAgent { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.title() must be("Are you sure you want to remove ACME Limited? - GOV.UK")
-        document.getElementById("pre-header").text() must include("Manage your ATED service")
-        document.getElementById("header").text() must include("Are you sure you want to remove ACME Limited?")
-        document.getElementById("yesNo_legend").text() must be("Are you sure you want to remove ACME Limited?")
-        document.getElementById("submit").text() must be("Confirm")
+        document.title() must be("agent.remove-client.header - GOV.UK")
+        document.getElementById("pre-header").text() must include("ated.screen-reader.section agent.edit-mandate-details.pre-header")
+        document.getElementById("header").text() must include("agent.remove-client.header")
+        document.getElementById("yesNo_legend").text() must be("agent.remove-client.header")
+        document.getElementById("submit").text() must be("confirm-button")
       }
     }
   }
@@ -159,8 +159,8 @@ class RemoveClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
       submitWithAuthorisedAgent(fakeRequest) { result =>
         status(result) must be(BAD_REQUEST)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementsByClass("error-list").text() must include("There is a problem with remove client question")
-        document.getElementsByClass("error-notification").text() must include("The remove client question must be answered")
+        document.getElementsByClass("error-list").text() must include("yes-no.error.general.yesNo")
+        document.getElementsByClass("error-notification").text() must include("yes-no.error.mandatory.removeClient")
       }
     }
   }
@@ -172,7 +172,7 @@ class RemoveClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         .thenReturn(Future.successful(mandate))
       submitWithAuthorisedAgent(fakeRequest) { result =>
         status(result) must be(SEE_OTHER)
-        redirectLocation(result).get must include(s"/mandate/agent/summary")
+        redirectLocation(result).get must include(s"/agent/summary")
       }
     }
 
@@ -214,7 +214,7 @@ class RemoveClientControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
       showConfirmationWithAuthorisedAgent { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.title() must be("You have removed your client - GOV.UK")
+        document.title() must be("agent.remove-client-confirmation.title - GOV.UK")
       }
     }
   }

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/SelectServiceControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/SelectServiceControllerSpec.scala
@@ -40,9 +40,9 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class SelectServiceControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
-  implicit val mockConfiguration: ServicesConfig = app.injector.instanceOf[ServicesConfig]
+  implicit val mockConfiguration: ServicesConfig = mock[ServicesConfig]
 
   "SelectServiceController" must {
 
@@ -74,11 +74,11 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedAgent { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Select a service - GOV.UK")
-          document.getElementById("header").text() must include("Select a service")
-          document.getElementById("pre-header").text() must be("This section is: Add a client")
-          document.getElementById("service_legend").text() must be("Select a service")
-          document.getElementById("submit").text() must be("Submit")
+          document.title() must be("agent.select-service.title - GOV.UK")
+          document.getElementById("header").text() must include("agent.select-service.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.add-a-client.sub-header")
+          document.getElementById("service_legend").text() must be("agent.select-service.header")
+          document.getElementById("submit").text() must be("submit-button")
         }
       }
 
@@ -90,7 +90,7 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
           .thenReturn (Future.successful(false))
         viewWithAuthorisedAgent { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/summary"))
+          redirectLocation(result) must be(Some("/agent/summary"))
         }
       }
 
@@ -99,7 +99,7 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
           .thenReturn (Future.successful(true))
         viewWithAuthorisedAgent { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/missing-email"))
+          redirectLocation(result) must be(Some("/agent/missing-email"))
         }
       }
     }
@@ -111,7 +111,7 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("service" -> "ated")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/summary"))
+          redirectLocation(result) must be(Some("/agent/summary"))
         }
       }
 
@@ -121,7 +121,7 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("service" -> "ated")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/missing-email"))
+          redirectLocation(result) must be(Some("/agent/missing-email"))
         }
       }
     }
@@ -132,8 +132,8 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the select service question")
-          document.getElementsByClass("error-notification").text() must include("You must select one service")
+          document.getElementsByClass("error-list").text() must include("agent.select-service.error.general.service")
+          document.getElementsByClass("error-notification").text() must include("agent.select-service.error.service")
         }
       }
     }
@@ -146,7 +146,7 @@ class SelectServiceControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
   class Setup {
     val controller = new SelectServiceController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAgentClientMandateService,
       implicitly,
       mockAppConfig,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UniqueAgentReferenceControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UniqueAgentReferenceControllerSpec.scala
@@ -37,13 +37,13 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class UniqueAgentReferenceControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class UniqueAgentReferenceControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   class Setup {
     val controller = new UniqueAgentReferenceController(
       mockAuthConnector,
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       implicitly,
       mockAppConfig
     )
@@ -79,7 +79,7 @@ class UniqueAgentReferenceControllerSpec extends PlaySpec with GuiceOneServerPer
         viewWithAuthorisedAgent(controller)(Some(ClientMandateDisplayDetails("test name", mandateId, agentLastUsedEmail))) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Your unique authorisation number is ABC123 - GOV.UK")
+          document.title() must be("agent.unique-reference.title - GOV.UK")
         }
       }
 
@@ -89,7 +89,7 @@ class UniqueAgentReferenceControllerSpec extends PlaySpec with GuiceOneServerPer
       "mandate ID is not found in cache" in new Setup {
         viewWithAuthorisedAgent(controller)() { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/agent/service"))
+          redirectLocation(result) must be(Some("/agent/service"))
         }
       }
     }

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateAddressDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateAddressDetailsControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AgentBuilder, Authenticated
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class UpdateAddressDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class UpdateAddressDetailsControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "UpdateAddressDetailsController" should {
 
@@ -86,7 +86,7 @@ class UpdateAddressDetailsControllerSpec extends PlaySpec with GuiceOneServerPer
         val fakeRequest = FakeRequest().withJsonBody(inputJson)
         saveWithAuthorisedUser(updateRegDetails, "abc")(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/agent/edit")
+          redirectLocation(result).get must include("/agent/edit")
         }
       }
     }
@@ -125,7 +125,7 @@ class UpdateAddressDetailsControllerSpec extends PlaySpec with GuiceOneServerPer
 
   class Setup {
     val controller = new UpdateAddressDetailsController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAgentClientMandateService,
       mockDataCacheService,
       implicitly,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateOcrDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateOcrDetailsControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AgentBuilder, Authenticated
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class UpdateOcrDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class UpdateOcrDetailsControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "UpdateOcrDetailsController" should {
 
@@ -88,7 +88,7 @@ class UpdateOcrDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuit
         val fakeRequest = FakeRequest().withJsonBody(inputJson)
         saveWithAuthorisedUser(updateRegDetails, "abc")(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/agent/edit")
+          redirectLocation(result).get must include("/agent/edit")
         }
       }
     }
@@ -131,7 +131,7 @@ class UpdateOcrDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuit
     val controller = new UpdateOcrDetailsController(
       mockAgentClientMandateService,
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/ChangeAgentControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/ChangeAgentControllerSpec.scala
@@ -39,7 +39,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ChangeAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class ChangeAgentControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "ChangeAgentController" must {
 
@@ -70,11 +70,11 @@ class ChangeAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         viewAuthorisedClient(request, { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Do you want to appoint another agent to act for you? - GOV.UK")
-          document.getElementById("header").text() must include("Do you want to appoint another agent to act for you?")
-          document.getElementById("pre-heading").text() must be("This section is: Manage your ATED service")
-          document.getElementById("yesNo_legend").text() must be("Do you want to appoint another agent to act for you?")
-          document.getElementById("submit").text() must be("Confirm")
+          document.title() must be("client.change-agent.title - GOV.UK")
+          document.getElementById("header").text() must include("client.change-agent.header")
+          document.getElementById("pre-heading").text() must be("ated.screen-reader.section agent.edit-mandate-details.pre-header")
+          document.getElementById("yesNo_legend").text() must be("client.change-agent.header")
+          document.getElementById("submit").text() must be("confirm-button")
         })
       }
     }
@@ -87,8 +87,8 @@ class ChangeAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         submitWithAuthorisedClient(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with change agent question")
-          document.getElementsByClass("error-notification").text() must include("The change agent question must be answered")
+          document.getElementsByClass("error-list").text() must include("yes-no.error.general.yesNo")
+          document.getElementsByClass("error-notification").text() must include("yes-no.error.mandatory.changeAgent")
         }
       }
 
@@ -120,7 +120,7 @@ class ChangeAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
     val controller = new ChangeAgentController(
       mockAgentClientMandateService,
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/ClientBannerPartialControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/ClientBannerPartialControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ClientBannerPartialControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class ClientBannerPartialControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "ClientBannerPartialController" must {
 
@@ -59,7 +59,7 @@ class ClientBannerPartialControllerSpec extends PlaySpec with GuiceOneServerPerS
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("You have requested Agent Ltd to act as your agent")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.approved")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/remove/1")
       }
     }
@@ -70,7 +70,7 @@ class ClientBannerPartialControllerSpec extends PlaySpec with GuiceOneServerPerS
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("Agent Ltd is now your appointed agent")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.active")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/remove/1")
       }
     }
@@ -81,7 +81,7 @@ class ClientBannerPartialControllerSpec extends PlaySpec with GuiceOneServerPerS
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("The ATED agent can no longer act for the client")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.cancelled")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/email")
       }
     }
@@ -92,7 +92,7 @@ class ClientBannerPartialControllerSpec extends PlaySpec with GuiceOneServerPerS
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("Agent Ltd has rejected your request to act as your agent")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.rejected")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/email")
       }
     }
@@ -105,7 +105,7 @@ class ClientBannerPartialControllerSpec extends PlaySpec with GuiceOneServerPerS
 
   class Setup {
     val controller = new ClientBannerPartialController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       mockMandateService,
       implicitly,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/CollectEmailControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/CollectEmailControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class CollectEmailControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "CollectEmailController" must {
 
@@ -66,12 +66,12 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         viewWithAuthorisedClient() { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your email address? - GOV.UK")
-          document.getElementById("header").text() must include("What is your email address?")
-          document.getElementById("pre-heading").text() must include("Appoint an agent")
-          document.getElementById("email_field").text() must be("What is your email address?")
+          document.title() must be("client.collect-email.title - GOV.UK")
+          document.getElementById("header").text() must include("client.collect-email.header")
+          document.getElementById("pre-heading").text() must include("ated.screen-reader.section client.collect-email.preheader")
+          document.getElementById("email_field").text() must be("client.collect-email.email.label")
           document.getElementById("email").`val`() must be("")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -80,7 +80,7 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         viewWithAuthorisedClient(Some(cached)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your email address? - GOV.UK")
+          document.title() must be("client.collect-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("aa@mail.com")
         }
       }
@@ -93,15 +93,15 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         editWithAuthorisedClient() { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your email address? - GOV.UK")
-          document.getElementById("header").text() must include("What is your email address?")
-          document.getElementById("pre-heading").text() must include("Appoint an agent")
-          document.getElementById("email_field").text() must be("What is your email address?")
+          document.title() must be("client.collect-email.title - GOV.UK")
+          document.getElementById("header").text() must include("client.collect-email.header")
+          document.getElementById("pre-heading").text() must include("ated.screen-reader.section client.collect-email.preheader")
+          document.getElementById("email_field").text() must be("client.collect-email.email.label")
           document.getElementById("email").`val`() must be("")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
 
-          document.getElementById("backLinkHref").text() must be("Back")
-          document.getElementById("backLinkHref").attr("href") must be("/mandate/client/review")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
+          document.getElementById("backLinkHref").attr("href") must be("/client/review")
         }
 
       }
@@ -112,10 +112,10 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         viewWithAuthorisedClient(Some(cached), Some("/api/anywhere")) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your email address? - GOV.UK")
+          document.title() must be("client.collect-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("aa@mail.com")
 
-          document.getElementById("backLinkHref").text() must be("Back")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
           document.getElementById("backLinkHref").attr("href") must be("/api/anywhere")
         }
       }
@@ -126,7 +126,7 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         viewWithAuthorisedClient(Some(cached), None) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your email address? - GOV.UK")
+          document.title() must be("client.collect-email.title - GOV.UK")
           document.getElementById("email").`val`() must be("aa@mail.com")
 
           document.getElementById("backLinkHref") must be(null)
@@ -142,9 +142,9 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         backWithAuthorisedClient(Some(cached), Some("http://backlink")) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your email address? - GOV.UK")
+          document.title() must be("client.collect-email.title - GOV.UK")
 
-          document.getElementById("backLinkHref").text() must be("Back")
+          document.getElementById("backLinkHref").text() must be("mandate.back")
           document.getElementById("backLinkHref").attr("href") must be("http://backlink")
         }
       }
@@ -158,7 +158,7 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         val returnData = ClientCache(email = Some(ClientEmail("aa@aa.com")))
         submitWithAuthorisedClient(fakeRequest, isValidEmail = true, cachedData = Some(cachedData), returnCache = returnData, mode = Some("edit")) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/review"))
+          redirectLocation(result) must be(Some("/client/review"))
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(1)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -169,7 +169,7 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         val returnData = ClientCache(email = Some(ClientEmail("aa@aa.com")))
         submitWithAuthorisedClient(fakeRequest, isValidEmail = true, cachedData = None, returnCache = returnData) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/search"))
+          redirectLocation(result) must be(Some("/client/search"))
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(1)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
         }
@@ -183,8 +183,8 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         submitWithAuthorisedClient(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter the email address you want to use for this client")
+          document.getElementsByClass("error-list").text() must include("client.collect-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.empty")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[String](ArgumentMatchers.eq(controller.backLinkId))(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0))
             .fetchAndGetFormData[ClientCache](ArgumentMatchers.eq(controller.clientFormId))(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -197,9 +197,9 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         submitWithAuthorisedClient(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
+          document.getElementsByClass("error-list").text() must include("client.collect-email.error.general.email")
           document.getElementsByClass("error-notification").text() must
-            include("The email address you want to use for this client must be 241 characters or less")
+            include("client.email.error.email.too.long")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[String](ArgumentMatchers.eq(controller.backLinkId))(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0))
             .fetchAndGetFormData[ClientCache](ArgumentMatchers.eq(controller.clientFormId))(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -213,8 +213,8 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
         submitWithAuthorisedClient(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter an email address in the correct format, like name@example.com")
+          document.getElementsByClass("error-list").text() must include("client.collect-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.invalid")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[String](ArgumentMatchers.eq(controller.backLinkId))(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0))
             .fetchAndGetFormData[ClientCache](ArgumentMatchers.eq(controller.clientFormId))(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -233,7 +233,7 @@ class CollectEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
   class Setup {
     val controller = new CollectEmailController(
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/EditEmailControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/EditEmailControllerSpec.scala
@@ -42,7 +42,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class EditEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class EditEmailControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "EditEmailController" must {
 
@@ -59,10 +59,10 @@ class EditEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with 
       viewWithAuthorisedClient(controller)("/api/anywhere") { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.title() must be("Edit your email address - GOV.UK")
+        document.title() must be("client.edit-email.title - GOV.UK")
         document.getElementById("email").`val`() must be("client@client.com")
 
-        document.getElementById("backLinkHref").text() must be("Back")
+        document.getElementById("backLinkHref").text() must be("mandate.back")
         document.getElementById("backLinkHref").attr("href") must be("/api/anywhere")
       }
     }
@@ -115,8 +115,8 @@ class EditEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with 
         submitWithAuthorisedClient(controller)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter the email address you want to use for this client")
+          document.getElementsByClass("error-list").text() must include("client.edit-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.empty")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[String](ArgumentMatchers.eq(controller.backLinkId))(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0))
             .fetchAndGetFormData[ClientCache](ArgumentMatchers.eq(controller.clientFormId))(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -129,9 +129,9 @@ class EditEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with 
         submitWithAuthorisedClient(controller)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
+          document.getElementsByClass("error-list").text() must include("client.edit-email.error.general.email")
           document.getElementsByClass("error-notification").text() must
-            include("The email address you want to use for this client must be 241 characters or less")
+            include("client.email.error.email.too.long")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[String](ArgumentMatchers.eq(controller.backLinkId))(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0))
             .fetchAndGetFormData[ClientCache](ArgumentMatchers.eq(controller.clientFormId))(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -144,8 +144,8 @@ class EditEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with 
         submitWithAuthorisedClient(controller)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the email address question")
-          document.getElementsByClass("error-notification").text() must include("Enter an email address in the correct format, like name@example.com")
+          document.getElementsByClass("error-list").text() must include("client.edit-email.error.general.email")
+          document.getElementsByClass("error-notification").text() must include("client.email.error.email.invalid")
           verify(mockDataCacheService, times(1)).fetchAndGetFormData[String](ArgumentMatchers.eq(controller.backLinkId))(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0))
             .fetchAndGetFormData[ClientCache](ArgumentMatchers.eq(controller.clientFormId))(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -190,7 +190,7 @@ class EditEmailControllerSpec extends PlaySpec with GuiceOneServerPerSuite with 
     val controller = new EditEmailController(
       mockDataCacheService,
       mockMandateService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/MandateConfirmationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/MandateConfirmationControllerSpec.scala
@@ -38,7 +38,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class MandateConfirmationControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class MandateConfirmationControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "MandateConfirmationController" must {
 
@@ -79,11 +79,11 @@ class MandateConfirmationControllerSpec extends PlaySpec with GuiceOneServerPerS
         viewAuthorisedClient(controller)(Some(mandate)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Your request to appoint an agent has been successfully submitted - GOV.UK")
-          document.getElementById("banner-text").text() must include("Your request to appoint name has been successfully submitted")
-          document.getElementById("notification").text() must be("Your agent will receive an email notification.")
-          document.getElementById("heading").text() must be("What happens next")
-          document.getElementById("finish_btn").text() must be("Sign out")
+          document.title() must be("client.agent-confirmation.title - GOV.UK")
+          document.getElementById("banner-text").text() must include("client.agent-confirmation.banner-text")
+          document.getElementById("notification").text() must be("client.agent-confirmation.notification")
+          document.getElementById("heading").text() must be("client.agent-confirmation.header")
+          document.getElementById("finish_btn").text() must be("client.agent-confirmation.finish-signout")
         }
       }
 
@@ -93,7 +93,7 @@ class MandateConfirmationControllerSpec extends PlaySpec with GuiceOneServerPerS
       "approved mandate is not returned in response" in new Setup {
         viewAuthorisedClient(controller)(None) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/review"))
+          redirectLocation(result) must be(Some("/client/review"))
         }
       }
     }
@@ -106,7 +106,7 @@ class MandateConfirmationControllerSpec extends PlaySpec with GuiceOneServerPerS
 
   class Setup {
     val controller = new MandateConfirmationController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       implicitly,
       mockAppConfig,
       mockDataCacheService,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/MandateDeclarationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/MandateDeclarationControllerSpec.scala
@@ -40,7 +40,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class MandateDeclarationControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with MockControllerSetup {
+class MandateDeclarationControllerSpec extends PlaySpec  with MockitoSugar with MockControllerSetup {
 
   "MandateDeclarationController" must {
 
@@ -63,12 +63,12 @@ class MandateDeclarationControllerSpec extends PlaySpec with GuiceOneServerPerSu
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
           document.title() must be("Declaration and consent - GOV.UK")
-          document.getElementById("header").text() must include("Declaration and consent")
-          document.getElementById("pre-heading").text() must include("Appoint an agent")
-          document.getElementById("declare-title").text() must be("I declare that:")
-          document.getElementById("agent-name").text() must be("name has agreed to act on my behalf in respect of ATED")
-          document.getElementById("dec-info").text() must be("the information I have provided is correct and complete")
-          document.getElementById("submit").text() must be("Agree and submit")
+          document.getElementById("header").text() must include("client.agent-declaration.header")
+          document.getElementById("pre-heading").text() must include("ated.screen-reader.section client.agent-declaration.pre-heading")
+          document.getElementById("declare-title").text() must be("client.agent-declaration.declare-header")
+          document.getElementById("agent-name").text() must be("client.agent-declaration.agent-name")
+          document.getElementById("dec-info").text() must be("client.agent-declaration.information")
+          document.getElementById("submit").text() must be("agree-submit")
         }
       }
     }
@@ -90,7 +90,7 @@ class MandateDeclarationControllerSpec extends PlaySpec with GuiceOneServerPerSu
         val mandateReturned = Some(mandate)
         submitWithAuthorisedClient(controller)(fakeRequest, cacheReturn, mandateReturned) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/confirmation"))
+          redirectLocation(result) must be(Some("/client/confirmation"))
         }
       }
     }
@@ -102,7 +102,7 @@ class MandateDeclarationControllerSpec extends PlaySpec with GuiceOneServerPerSu
         val cacheReturn = Some(ClientCache(mandate = Some(mandate)))
         submitWithAuthorisedClient(controller)(fakeRequest, cacheReturn) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/review"))
+          redirectLocation(result) must be(Some("/client/review"))
         }
       }
     }
@@ -112,7 +112,7 @@ class MandateDeclarationControllerSpec extends PlaySpec with GuiceOneServerPerSu
         val fakeRequest = FakeRequest().withFormUrlEncodedBody()
         submitWithAuthorisedClient(controller)(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/review"))
+          redirectLocation(result) must be(Some("/client/review"))
         }
       }
     }
@@ -141,7 +141,7 @@ class MandateDeclarationControllerSpec extends PlaySpec with GuiceOneServerPerSu
       mockDataCacheService,
       mockMandateService,
       mockAuthConnector,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       implicitly,
       mockAppConfig
     )

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/RemoveAgentControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/RemoveAgentControllerSpec.scala
@@ -43,7 +43,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class RemoveAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class RemoveAgentControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "RemoveAgentController" must {
 
@@ -76,11 +76,11 @@ class RemoveAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         viewAuthorisedClient(controller)(request, "/app/return") { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Confirm Agent Removal - GOV.UK")
-          document.getElementById("header").text() must include("Are you sure you want to cancel the authority for Agent Ltd to act on your behalf for ATED?")
-          document.getElementById("pre-header").text() must be("This section is: Manage your ATED service")
-          document.getElementById("yesNo_legend").text() must be("Are you sure you want to cancel the authority for Agent Ltd to act on your behalf for ATED?")
-          document.getElementById("submit").text() must be("Confirm")
+          document.title() must be("client.remove-agent.title - GOV.UK")
+          document.getElementById("header").text() must include("client.remove-agent.header")
+          document.getElementById("pre-header").text() must be("ated.screen-reader.section agent.edit-mandate-details.pre-header")
+          document.getElementById("yesNo_legend").text() must be("client.remove-agent.header")
+          document.getElementById("submit").text() must be("confirm-button")
         }
       }
 
@@ -109,8 +109,8 @@ class RemoveAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         submitWithAuthorisedClient(controller)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with remove agent question")
-          document.getElementsByClass("error-notification").text() must include("The remove agent question must be answered")
+          document.getElementsByClass("error-list").text() must include("yes-no.error.general.yesNo")
+          document.getElementsByClass("error-notification").text() must include("yes-no.error.mandatory.removeAgent")
         }
       }
 
@@ -119,7 +119,7 @@ class RemoveAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         val fakeRequest = FakeRequest().withFormUrlEncodedBody("yesNo" -> "true")
         submitWithAuthorisedClient(controller)(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result).get must include("/mandate/client/change")
+          redirectLocation(result).get must include("/client/change")
         }
       }
 
@@ -187,11 +187,11 @@ class RemoveAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         confirmationWithAuthorisedClient(controller) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("You have successfully removed your agent - GOV.UK")
-          document.getElementById("banner-text").text() must include("You have removed Agent Limited as your agent")
-          document.getElementById("notification").text() must be("Your agent will receive an email notification.")
-          document.getElementById("heading-1").text() must be("You can")
-                    document.getElementById("return_to_service_button").text() must be("Your ATED online service")
+          document.title() must be("client.remove-agent-confirmation.title - GOV.UK")
+          document.getElementById("banner-text").text() must include("client.remove-agent-confirmation.banner-text")
+          document.getElementById("notification").text() must be("client.agent-confirmation.notification")
+          document.getElementById("heading-1").text() must be("client.remove-agent-confirmation.header")
+          document.getElementById("return_to_service_button").text() must be("client.remove-agent-confirmation.service_button")
         }
       }
     }
@@ -209,7 +209,7 @@ class RemoveAgentControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
       mockAgentClientMandateService,
       mockDataCacheService,
       mockDelegationConnector,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/ReviewMandateControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/ReviewMandateControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ReviewMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class ReviewMandateControllerSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "ReviewMandateController" must {
 
@@ -71,13 +71,13 @@ class ReviewMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedClient(reviewMandateController)(Some(returnData)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("Check that this is the agency you want to appoint - GOV.UK")
-          document.getElementById("header").text() must include("Check that this is the agency you want to appoint")
-          document.getElementById("pre-heading").text() must include("Appoint an agent")
-          document.getElementById("agent-ref-name-label").text() must be("Unique authorisation number")
-          document.getElementById("your-email-label").text() must be("Your email address")
-          document.getElementById("agent-disclaimer").text() must be("Appointing name will let them see all the details in your old returns.")
-          document.getElementById("submit").text() must be("Confirm and appoint agent")
+          document.title() must be("client.review-agent.title - GOV.UK")
+          document.getElementById("header").text() must include("client.review-agent.header")
+          document.getElementById("pre-heading").text() must include("ated.screen-reader.section client.review-agent.preheader")
+          document.getElementById("agent-ref-name-label").text() must be("client.review-agent.agent-reference")
+          document.getElementById("your-email-label").text() must be("client.review-agent.own.email")
+          document.getElementById("agent-disclaimer").text() must be("client.review-agent.disclaimer")
+          document.getElementById("submit").text() must be("client.review-agent.submit")
         }
       }
 
@@ -89,7 +89,7 @@ class ReviewMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       "client requests(GET) for review mandate view, but mandate has not been cached on search mandate submit" in new Setup {
         viewWithAuthorisedClient(reviewMandateController)(Some(ClientCache(email = Some(ClientEmail(email = "aa@test.com"))))) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/search"))
+          redirectLocation(result) must be(Some("/client/search"))
         }
       }
 
@@ -100,7 +100,7 @@ class ReviewMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       "client requests(GET) for review mandate view, but there is no cache" in new Setup {
         viewWithAuthorisedClient(reviewMandateController)() { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/email"))
+          redirectLocation(result) must be(Some("/client/email"))
         }
       }
 
@@ -110,7 +110,7 @@ class ReviewMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       "client submits form" in new Setup {
         submitWithAuthorisedClient(reviewMandateController) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/declaration"))
+          redirectLocation(result) must be(Some("/client/declaration"))
         }
       }
     }
@@ -123,7 +123,7 @@ class ReviewMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
   class Setup {
     val reviewMandateController = new ReviewMandateController(
       mockDataCacheService,
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       implicitly,
       mockAppConfig

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/SearchMandateControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/client/SearchMandateControllerSpec.scala
@@ -41,7 +41,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach  with MockControllerSetup {
+class SearchMandateControllerSpec extends PlaySpec with MockitoSugar with BeforeAndAfterEach  with MockControllerSetup {
 
   "SearchMandateController" must {
 
@@ -73,10 +73,10 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedClient(searchMandateController)() { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your unique authorisation number? - GOV.UK")
-          document.getElementById("header").text() must include("What is your unique authorisation number?")
+          document.title() must be("client.search-mandate.title - GOV.UK")
+          document.getElementById("header").text() must include("client.search-mandate.header")
           document.getElementById("mandateRef").`val`() must be("")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -85,10 +85,10 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedClient(searchMandateController)(Some(cached)) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title() must be("What is your unique authorisation number? - GOV.UK")
-          document.getElementById("header").text() must include("What is your unique authorisation number?")
+          document.title() must be("client.search-mandate.title - GOV.UK")
+          document.getElementById("header").text() must include("client.search-mandate.header")
           document.getElementById("mandateRef").`val`() must be("ABC123")
-          document.getElementById("submit").text() must be("Continue")
+          document.getElementById("submit").text() must be("continue-button")
         }
       }
 
@@ -105,7 +105,7 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val returnCache = cachedData.copy(mandate = Some(mandate1))
         submitWithAuthorisedClient(searchMandateController)(request = fakeRequest, cachedData = Some(cachedData), mandate = Some(mandate1), returnCache = returnCache) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/review"))
+          redirectLocation(result) must be(Some("/client/review"))
         }
       }
 
@@ -119,7 +119,7 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val returnCache = cachedData.copy(mandate = Some(mandate1))
         submitWithAuthorisedClient(searchMandateController)(request = fakeRequest, cachedData = Some(cachedData), mandate = Some(mandate1), returnCache = returnCache) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/review"))
+          redirectLocation(result) must be(Some("/client/review"))
         }
       }
 
@@ -143,7 +143,7 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         val returnCache = ClientCache(mandate = Some(mandate))
         submitWithAuthorisedClient(searchMandateController)(request = fakeRequest, cachedData = None, mandate = Some(mandate), returnCache = returnCache) { result =>
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some("/mandate/client/email"))
+          redirectLocation(result) must be(Some("/client/email"))
         }
       }
     }
@@ -155,8 +155,8 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         submitWithAuthorisedClient(searchMandateController)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the unique authorisation number question")
-          document.getElementsByClass("error-notification").text() must include("You must answer unique authorisation number question")
+          document.getElementsByClass("error-list").text() must include("client.search-mandate.error.general.mandateRef")
+          document.getElementsByClass("error-notification").text() must include("client.search-mandate.error.mandateRef")
           verify(mockMandateService, times(0)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -168,8 +168,8 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         submitWithAuthorisedClient(searchMandateController)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the unique authorisation number question")
-          document.getElementsByClass("error-notification").text() must include("A unique authorisation number cannot be more than 8 characters")
+          document.getElementsByClass("error-list").text() must include("client.search-mandate.error.general.mandateRef")
+          document.getElementsByClass("error-notification").text() must include("client.search-mandate.error.mandateRef.length")
           verify(mockMandateService, times(0)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -181,9 +181,9 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         submitWithAuthorisedClient(searchMandateController)(fakeRequest) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the unique authorisation number question")
+          document.getElementsByClass("error-list").text() must include("client.search-mandate.error.general.mandateRef")
           document.getElementsByClass("error-notification").text() must
-            include("The unique authorisation number you entered cannot be found. Check the number, or enter a different number.")
+            include("lient.search-mandate.error.mandateRef.not-found-by-mandate-service")
           verify(mockMandateService, times(1)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -196,9 +196,9 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         submitWithAuthorisedClient(searchMandateController)(request = fakeRequest, cachedData = None, mandate = Some(mandate1), returnCache = returnCache) { result =>
           status(result) must be(BAD_REQUEST)
           val document = Jsoup.parse(contentAsString(result))
-          document.getElementsByClass("error-list").text() must include("There is a problem with the unique authorisation number question")
+          document.getElementsByClass("error-list").text() must include("client.search-mandate.error.general.mandateRef")
           document.getElementsByClass("error-notification").text() must
-            include("The unique authorisation number you entered has already been used. Check the number, or enter a different number.")
+            include("client.search-mandate.error.mandateRef.already-used-by-mandate-service")
           verify(mockMandateService, times(1)).fetchClientMandate(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).fetchAndGetFormData[ClientCache](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
           verify(mockDataCacheService, times(0)).cacheFormData[ClientCache](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
@@ -237,7 +237,7 @@ class SearchMandateControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
   class Setup {
     val searchMandateController = new SearchMandateController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       mockDataCacheService,
       mockMandateService,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/internal/ClientBannerPartialInternalControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/internal/ClientBannerPartialInternalControllerSpec.scala
@@ -39,7 +39,7 @@ import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ClientBannerPartialInternalControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
+class ClientBannerPartialInternalControllerSpec extends PlaySpec with MockitoSugar with BeforeAndAfterEach with MockControllerSetup {
 
   "ClientBannerPartialController" must {
 
@@ -57,7 +57,7 @@ class ClientBannerPartialInternalControllerSpec extends PlaySpec with GuiceOneSe
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("You have requested Agent Ltd to act as your agent")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.approved")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/remove/1")
       }
     }
@@ -68,7 +68,7 @@ class ClientBannerPartialInternalControllerSpec extends PlaySpec with GuiceOneSe
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("Agent Ltd is now your appointed agent")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.active")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/remove/1")
       }
     }
@@ -79,7 +79,7 @@ class ClientBannerPartialInternalControllerSpec extends PlaySpec with GuiceOneSe
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("The ATED agent can no longer act for the client")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.cancelled")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/email")
       }
     }
@@ -90,7 +90,7 @@ class ClientBannerPartialInternalControllerSpec extends PlaySpec with GuiceOneSe
       viewWithAuthorisedClient() { result =>
         status(result) must be(OK)
         val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("client-banner-text").text() must include("Agent Ltd has rejected your request to act as your agent")
+        document.getElementById("client-banner-text").text() must include("client.banner.text.rejected")
         document.getElementById("client-banner-text-link").attr("href") must include("/client/email")
       }
     }
@@ -103,7 +103,7 @@ class ClientBannerPartialInternalControllerSpec extends PlaySpec with GuiceOneSe
 
   class Setup {
     val controller = new ClientBannerPartialInternalController(
-      app.injector.instanceOf[MessagesControllerComponents],
+      stubbedMessagesControllerComponents,
       mockAuthConnector,
       mockMandateService,
       implicitly,

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
@@ -40,7 +40,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 
-class AgentClientMandateServiceSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class AgentClientMandateServiceSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
   class Setup {
     val service = new AgentClientMandateService(

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/DataCacheServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/DataCacheServiceSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
 import scala.concurrent.Future
 
-class DataCacheServiceSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+class DataCacheServiceSpec extends PlaySpec  with MockitoSugar with BeforeAndAfterEach {
 
   case class FormData(name: String)
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/utils/AgentClientMandateUtilsSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/utils/AgentClientMandateUtilsSpec.scala
@@ -17,16 +17,16 @@
 package unit.uk.gov.hmrc.agentclientmandate.utils
 
 import org.joda.time.DateTime
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.models._
 import uk.gov.hmrc.agentclientmandate.utils.AgentClientMandateUtils
 import unit.uk.gov.hmrc.agentclientmandate.builders.AgentBuilder
 
-class AgentClientMandateUtilsSpec extends PlaySpec with GuiceOneServerPerSuite {
+class AgentClientMandateUtilsSpec extends PlaySpec with MockitoSugar {
 
-  val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  val appConfig: AppConfig = mock[AppConfig]
 
   "AgentClientMandateUtils" must {
     "validateUTR" must {
@@ -58,13 +58,6 @@ class AgentClientMandateUtilsSpec extends PlaySpec with GuiceOneServerPerSuite {
       "a valid status is passed" in {
         AgentClientMandateUtils.checkStatus(Status.PendingActivation) must be("Pending")
       }
-    }
-  }
-  "getIsoCodeTupleList" must {
-    "bring the correct country from the file" in {
-      appConfig.getIsoCodeTupleList must contain(("US", "USA :United States of America"))
-      appConfig.getIsoCodeTupleList must contain(("GB", "United Kingdom :UK, GB, Great Britain"))
-      appConfig.getIsoCodeTupleList must contain(("GB", "United Kingdom :UK, GB, Great Britain"))
     }
   }
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/utils/DelegationUtilsSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/utils/DelegationUtilsSpec.scala
@@ -16,10 +16,10 @@
 
 package unit.uk.gov.hmrc.agentclientmandate.utils
 
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Configuration
 import play.api.i18n.Messages
 import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.models.PrincipalTaxIdentifiers
@@ -27,13 +27,25 @@ import uk.gov.hmrc.agentclientmandate.utils.DelegationUtils
 import uk.gov.hmrc.domain.{AtedUtr, Generator}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
-class DelegationUtilsSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar {
+class DelegationUtilsSpec extends PlaySpec  with MockitoSugar {
 
   val atedUtr: AtedUtr = new Generator().nextAtedUtr
 
-  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val appConfig: AppConfig = mock[AppConfig]
   implicit val messages: Messages = mock[Messages]
-  implicit val config: ServicesConfig = appConfig.servicesConfig
+
+
+  implicit val mockServicesConfig: ServicesConfig = mock[ServicesConfig]
+
+  when(appConfig.servicesConfig)
+    .thenReturn(mockServicesConfig)
+
+  when(mockServicesConfig.getString(ArgumentMatchers.eq("microservice.delegated-service-redirect-url.ated")))
+    .thenReturn("http://localhost:9916/ated/account-summary")
+  when(mockServicesConfig.getString(ArgumentMatchers.eq("microservice.delegated-service-home-url.ated")))
+    .thenReturn("https://www.gov.uk/guidance/register-for-the-annual-tax-on-enveloped-dwellings-online-service")
+  when(mockServicesConfig.getString(ArgumentMatchers.eq("microservice.return-part-url")))
+    .thenReturn("http://localhost:9959/mandate/agent/summary")
 
   "DelegationUtils" must {
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/utils/FeatureSwitchSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/utils/FeatureSwitchSpec.scala
@@ -17,6 +17,7 @@
 package unit.uk.gov.hmrc.agentclientmandate.utils
 
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Configuration
@@ -24,13 +25,13 @@ import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.utils.{FeatureSwitch, MandateFeatureSwitches}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
-class FeatureSwitchSpec extends PlaySpec with GuiceOneServerPerSuite with BeforeAndAfterEach {
+class FeatureSwitchSpec extends PlaySpec with MockitoSugar with BeforeAndAfterEach {
 
   override def beforeEach: Unit = {
     System.clearProperty("feature.test")
   }
 
-  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val appConfig: AppConfig = mock[AppConfig]
   implicit val config: ServicesConfig = appConfig.servicesConfig
 
   "FeatureSwitch" should {

--- a/test/views/agent/AgentDetailsFeatureSpec.scala
+++ b/test/views/agent/AgentDetailsFeatureSpec.scala
@@ -25,10 +25,9 @@ import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.views
 import unit.uk.gov.hmrc.agentclientmandate.builders.AgentBuilder
 
-class AgentDetailsFeatureSpec extends FeatureSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
+class AgentDetailsFeatureSpec extends FeatureSpec  with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
 
   implicit val request = FakeRequest()
-  implicit val appConfig : AppConfig = app.injector.instanceOf[AppConfig]
 
   feature("The user can view the agent details page") {
 
@@ -43,23 +42,23 @@ class AgentDetailsFeatureSpec extends FeatureSpec with GuiceOneServerPerSuite wi
 
       val document = Jsoup.parse(html.toString())
       Then("The title should match - Your details - GOV.UK")
-      assert(document.title() === "Your details - GOV.UK")
+      assert(document.title() === "agent.edit-details.title - GOV.UK")
 
       And("The pre-header text is - Edit details")
-      assert(document.getElementById("pre-header").text() === "This section is: Edit details")
+      assert(document.getElementById("pre-header").text() === "ated.screen-reader.section agent.edit-details.sub-header")
       And("The header text is - Your details")
-      assert(document.getElementById("agency-details-header").text() === "Your details")
+      assert(document.getElementById("agency-details-header").text() === "agent.edit-details.header")
 
       When("The user views the table of information")
 
       Then("The agency name header text is - Business Name]")
-      assert(document.getElementById("agency-name-header").text() === "Business Name")
+      assert(document.getElementById("agency-name-header").text() === "agent.edit-details.agency.name")
 
       And("The agency name is - Org Name")
       assert(document.getElementById("agency-name-val").text() === "Org Name")
 
       And("The agency address header is - Address")
-      assert(document.getElementById("agency-address-header").text() === "Address")
+      assert(document.getElementById("agency-address-header").text() === "agent.edit-details.registered.address")
 
       And("The agency address details shows - address1 address2 FR")
       assert(document.getElementById("agency-address-val").text() === "address1 address2 FR")

--- a/test/views/agent/RejectClientFeatureSpec.scala
+++ b/test/views/agent/RejectClientFeatureSpec.scala
@@ -26,10 +26,9 @@ import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.YesNoQuestionForm
 import uk.gov.hmrc.agentclientmandate.views
 
-class RejectClientFeatureSpec extends FeatureSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
+class RejectClientFeatureSpec extends FeatureSpec  with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
 
   implicit val request = FakeRequest()
-  implicit val appConfig : AppConfig = app.injector.instanceOf[AppConfig]
 
   feature("The user can view the reject client page") {
 
@@ -44,23 +43,23 @@ class RejectClientFeatureSpec extends FeatureSpec with GuiceOneServerPerSuite wi
 
       val document = Jsoup.parse(html.toString())
       Then("The title should match - Are you sure you want to reject the request from this client? - GOV.UK")
-      assert(document.title() === "Are you sure you want to reject the request from this client? - GOV.UK")
+      assert(document.title() === "agent.reject-client.title - GOV.UK")
       And("The pre-header text is - Manage your ATED service")
-      assert(document.getElementById("pre-heading").text() === "This section is: Manage your ATED service")
+      assert(document.getElementById("pre-heading").text() === "ated.screen-reader.section agent.edit-mandate-details.pre-header")
       And("The header text is - Are you sure you want to reject the request from ACME Limited?")
-      assert(document.getElementById("heading").text() === "Are you sure you want to reject the request from ACME Limited?")
+      assert(document.getElementById("heading").text() === "agent.reject-client.header")
 
       And("The reject text is - Rejecting a client request means you will not be able to act on their behalf unless they submit another request.")
-      assert(document.getElementById("reject-text").text() === "Rejecting a client request means you will not be able to act for them unless they submit another request.")
+      assert(document.getElementById("reject-text").text() === "agent.reject-client.text")
 
       And("The yes no radio buttons - exist and are set to Yes and No")
       assert(document.getElementById("yesNo-true").attr("value") === "true")
-      assert(document.getElementById("yesNo-true_field").text() === "Yes")
+      assert(document.getElementById("yesNo-true_field").text() === "radio-yes")
       assert(document.getElementById("yesNo-false").attr("value") === "false")
-      assert(document.getElementById("yesNo-false_field").text() === "No")
+      assert(document.getElementById("yesNo-false_field").text() === "radio-no")
 
       And("The submit button is - Confirm")
-      assert(document.getElementById("submit").text() === "Confirm")
+      assert(document.getElementById("submit").text() === "confirm-button")
 
     }
   }

--- a/test/views/agent/UniqueAgentReferenceFeatureSpec.scala
+++ b/test/views/agent/UniqueAgentReferenceFeatureSpec.scala
@@ -27,10 +27,9 @@ import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.ClientMandateDisplayDet
 import uk.gov.hmrc.agentclientmandate.views
 
 
-class UniqueAgentReferenceFeatureSpec extends FeatureSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
+class UniqueAgentReferenceFeatureSpec extends FeatureSpec  with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
 
   implicit val request = FakeRequest()
-  implicit val appConfig : AppConfig = app.injector.instanceOf[AppConfig]
 
   feature("The user can view the reject client page") {
 
@@ -48,25 +47,25 @@ class UniqueAgentReferenceFeatureSpec extends FeatureSpec with GuiceOneServerPer
 
       val document = Jsoup.parse(html.toString())
       Then("The title should match - Your unique agent reference is ABC123 - GOV.UK")
-      assert(document.title() === "Your unique authorisation number is ABC123 - GOV.UK")
+      assert(document.title() === "agent.unique-reference.title - GOV.UK")
       And("The banner text is - Your unique authorisation number for test name is ABC123")
-      assert(document.getElementById("banner-text").text() === "Your unique authorisation number for test name is ABC123")
+      assert(document.getElementById("banner-text").text() === "agent.unique-reference.header")
       And("The screen text is - What you must do next")
-      assert(document.getElementById("what-you-must-do").text() === "What you must do next")
+      assert(document.getElementById("what-you-must-do").text() === "agent.unique-reference.next.heading.text")
 
       And("The agents instructions")
-      assert(document.getElementById("agent-instruction-1").text() === "You must give your client the unique authorisation number ABC123 so they can authorise you to act for them. This number is available from your list of clients.")
-      assert(document.getElementById("agent-instruction-2").text() === "When your client authorises you, we will send you an email. You must sign in and accept their request within 28 days or you will need to start from the beginning.")
+      assert(document.getElementById("agent-instruction-1").text() === "agent.unique-reference.do-next1")
+      assert(document.getElementById("agent-instruction-2").text() === "agent.unique-reference.do-next2")
 
       And("The client-instruction - should be correct for the relevant service")
-      assert(document.getElementById("tell-your-client").text() === "What to tell your client")
-      assert(document.getElementById("agent.unique-reference.details.text.1").text() === "Sign in to your organisation Government Gateway account. If you do not have an account, create a Government Gateway account.")
-      assert(document.getElementById("agent.unique-reference.details.text.2").text() === "When you are signed in, register for ATED using your registered name and Unique Taxpayer Reference (UTR).")
-      assert(document.getElementById("agent.unique-reference.details.text.3").text() === "Add your or your agent’s contact email address.")
-      assert(document.getElementById("agent.unique-reference.details.text.4").text() === "Enter the unique authorisation number ABC123.")
+      assert(document.getElementById("tell-your-client").text() === "agent.unique-reference.tell-client")
+      assert(document.getElementById("agent.unique-reference.details.text.2").text() === "agent.unique-reference.details.text.2")
+      assert(document.getElementById("agent.unique-reference.details.text.1").text() === "agent.unique-reference.details.text.1")
+      assert(document.getElementById("agent.unique-reference.details.text.3").text() === "agent.unique-reference.details.text.3")
+      assert(document.getElementById("agent.unique-reference.details.text.4").text() === "agent.unique-reference.details.text.4")
 
       And("The submit : View all my clients has the correct link")
-      assert(document.getElementById("submit").text() === "View all my clients")
+      assert(document.getElementById("submit").text() === "agent.unique-reference.button")
 
     }
   }

--- a/test/views/agent/agentSummary/ViewTestHelper.scala
+++ b/test/views/agent/agentSummary/ViewTestHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package views.agent
+package views.agent.agentSummary
 
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
@@ -60,11 +60,11 @@ trait ViewTestHelper {
   when(mockAppConfig.configuration)
     .thenReturn(mockConfig)
 
+  when(mockAppConfig.serviceSignOutUrl(ArgumentMatchers.any()))
+    .thenReturn("http://localhost:9916/ated/logout")
+
   val optimizelySnippet: OptimizelySnippet = new OptimizelySnippet(mockOptConfig)
   val gtmSnippet: GTMSnippet = new GTMSnippet(mockGtmConfig)
-
-  when(mockServicesConfig.getString(ArgumentMatchers.eq("microservice.delegated-service-sign-out-url.ated")))
-    .thenReturn("http://localhost:9916/ated/logout")
 
   when(mockAppConfig.customHeadTemplate)
     .thenReturn(new Head(optimizelySnippet, mockAssetsConfig, gtmSnippet))

--- a/test/views/agent/agentSummary/clientsViewSpec.scala
+++ b/test/views/agent/agentSummary/clientsViewSpec.scala
@@ -20,7 +20,6 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Lang, Messages}
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.FakeRequest
@@ -30,15 +29,13 @@ import uk.gov.hmrc.agentclientmandate.service.Mandates
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.FilterClientsForm._
 import uk.gov.hmrc.agentclientmandate.views
 import uk.gov.hmrc.domain.{AtedUtr, Generator}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import unit.uk.gov.hmrc.agentclientmandate.builders.AgentBuilder
 
-class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with GivenWhenThen{
+class clientsViewSpec extends FeatureSpec  with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
 
   val registeredAddressDetails = RegisteredAddressDetails("123 Fake Street", "Somewhere", None, None, None, "GB")
   val agentDetails: AgentDetails = AgentBuilder.buildAgentDetails
-
-  private val mcc: MessagesControllerComponents = app.injector.instanceOf[MessagesControllerComponents]
-  implicit val messages: Messages = mcc.messagesApi.preferred(Seq(Lang.defaultLang))
 
   val mandateId = "12345678"
   val time1: DateTime = DateTime.now()
@@ -75,7 +72,6 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
     statusHistory = Seq(MandateStatus(Status.New, time1, "credId")), Subscription(None, Service("ated", "ATED")), clientDisplayName = "client display name 5")
 
   implicit val request = FakeRequest()
-  implicit val appConfig : AppConfig = app.injector.instanceOf[AppConfig]
 
   feature("The agent can view the agent summary page when they have both clients and pending clients") {
 
@@ -93,18 +89,18 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val html = views.html.agent.agentSummary.clients("ATED", Mandates(activeMandates, pendingMandates), agentDetails, None, "", filterClientsForm)
 
       val document = Jsoup.parse(html.toString())
-      Then("The title should match - ATED clients - GOV.UK")
-      assert(document.title() === "ATED clients - GOV.UK")
+      Then("The title should match - client.summary.title - GOV.UK")
+      assert(document.title() === "client.summary.title - GOV.UK")
 
       And("The Clients tab - should exist and have 1 item")
-      assert(document.getElementById("clients").text === "Current (1) selected")
+      assert(document.getElementById("clients").text === "client.summary.client-active.title selected")
       And("The Pending Clients tab - should not exist")
-      assert(document.getElementById("pending-clients").text === "Requests (1)")
+      assert(document.getElementById("pending-clients").text === "client.summary.client-pending.title")
 
       And("The Add Client Button - should not exist")
       assert(document.getElementById("add-client-btn") === null)
       And("The Add Client Link - should exist")
-      assert(document.getElementById("add-client-link").text() === "Add a client")
+      assert(document.getElementById("add-client-link").text() === "client.summary.add-client")
     }
 
     scenario("agent has visited the page and has clients but no pending clients") {
@@ -118,22 +114,22 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val html = views.html.agent.agentSummary.clients("ATED", Mandates(activeMandates, Nil), agentDetails, None, "", filterClientsForm)
 
       val document = Jsoup.parse(html.toString())
-      Then("The title should match - ATED clients - GOV.UK")
-      assert(document.title() === "ATED clients - GOV.UK")
+      Then("The title should match - client.summary.title - GOV.UK")
+      assert(document.title() === "client.summary.title - GOV.UK")
 
       And("The Clients tab - should exist and have 1 item")
-      assert(document.getElementById("clients").text === "Current (1) selected")
+      assert(document.getElementById("clients").text === "client.summary.client-active.title selected")
       And("The Pending Clients tab - should not exist")
       assert(document.getElementById("pending-clients") === null)
 
       And("The Clients table - has the correct data and View link")
       assert(document.getElementById("client-name-0").text === "client display name 2")
-      assert(document.getElementById("client-link-0").text === "View details for client display name 2")
+      assert(document.getElementById("client-link-0").text === "client.summary.client-view client.summary.client-details-for client display name 2")
 
       And("The Add Client Button - should not exist")
       assert(document.getElementById("add-client-btn") === null)
       And("The Add Client Link - should exist")
-      assert(document.getElementById("add-client-link").text() === "Add a client")
+      assert(document.getElementById("add-client-link").text() === "client.summary.add-client")
 
       And("The filter box should not exist")
       assert(document.getElementById("filterbox") == null)
@@ -152,19 +148,19 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val document = Jsoup.parse(html.toString())
 
       Then("The Clients tab - should exist and have 15 items")
-      assert(document.getElementById("clients").text === "Current (15) selected")
+      assert(document.getElementById("clients").text === "client.summary.client-active.title selected")
 
       And("The Clients table - has the correct data and View link")
       assert(document.getElementById("client-name-0").text === "client display name 2")
-      assert(document.getElementById("client-link-0").text === "View details for client display name 2")
+      assert(document.getElementById("client-link-0").text === "client.summary.client-view client.summary.client-details-for client display name 2")
 
       And("The Add Client Button - should not exist")
       assert(document.getElementById("add-client-btn") === null)
       And("The Add Client Link - should exist")
-      assert(document.getElementById("add-client-link").text() === "Add a client")
+      assert(document.getElementById("add-client-link").text() === "client.summary.add-client")
 
       And("The filter box should exist")
-      assert(document.getElementById("filter-clients").text === "Filter clients")
+      assert(document.getElementById("filter-clients").text === "client.summary.filter-clients")
     }
 
     scenario("agent has visited the page and has filtered clients but there no results") {
@@ -178,7 +174,7 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val document = Jsoup.parse(html.toString())
 
       Then("The Clients tab - should exist and have 0 items")
-      assert(document.getElementById("clients").text === "Current (0) selected")
+      assert(document.getElementById("clients").text === "client.summary.client-active.title selected")
 
       And("I should not see the clients cancelled panel")
       assert(document.getElementById("client-cancelled-title") === null)
@@ -186,13 +182,13 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       And("The Add Client Button - should not exist")
       assert(document.getElementById("add-client-btn") === null)
       And("The Add Client Link - should exist")
-      assert(document.getElementById("add-client-link").text() === "Add a client")
+      assert(document.getElementById("add-client-link").text() === "client.summary.add-client")
 
       And("The filter box should exist")
-      assert(document.getElementById("filter-clients").text === "Filter clients")
+      assert(document.getElementById("filter-clients").text === "client.summary.filter-clients")
 
       And("The text for no results should exist")
-      assert(document.getElementById("filter-no-results").text === "No clients found")
+      assert(document.getElementById("filter-no-results").text === "client.summary.no_clients_found")
     }
 
     scenario("agent visits summary page with clients cancelled in last 28 days") {
@@ -203,7 +199,7 @@ class clientsViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val document = Jsoup.parse(html.toString())
 
       Then("I should see the clients cancelled panel")
-      assert(document.getElementById("client-cancelled-title").text === "Your authority to act for these clients has been removed:")
+      assert(document.getElementById("client-cancelled-title").text === "client.summary.client-cancelled.text")
 
       And("I should see the name of the client")
       assert(document.getElementById("client-cancelled-name-0").text === "AAA")

--- a/test/views/agent/agentSummary/noClientsNoPendingViewSpec.scala
+++ b/test/views/agent/agentSummary/noClientsNoPendingViewSpec.scala
@@ -28,15 +28,13 @@ import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.models._
 import uk.gov.hmrc.agentclientmandate.views
 import uk.gov.hmrc.domain.{AtedUtr, Generator}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import unit.uk.gov.hmrc.agentclientmandate.builders.AgentBuilder
 
-class noClientsNoPendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with GivenWhenThen {
+class noClientsNoPendingViewSpec extends FeatureSpec  with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
 
   val registeredAddressDetails = RegisteredAddressDetails("123 Fake Street", "Somewhere", None, None, None, "GB")
   val agentDetails: AgentDetails = AgentBuilder.buildAgentDetails
-
-  private val mcc: MessagesControllerComponents = app.injector.instanceOf[MessagesControllerComponents]
-  implicit val messages: Messages = mcc.messagesApi.preferred(Seq(Lang.defaultLang))
 
   val mandateId = "12345678"
   val time1: DateTime = DateTime.now()
@@ -44,7 +42,6 @@ class noClientsNoPendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite
   val atedUtr: AtedUtr = new Generator().nextAtedUtr
 
   implicit val request = FakeRequest()
-  implicit val appConfig : AppConfig = app.injector.instanceOf[AppConfig]
 
   feature("The agent can view the agent summary page but they have no clients and no pending clients") {
 
@@ -58,17 +55,17 @@ class noClientsNoPendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite
       val html = views.html.agent.agentSummary.noClientsNoPending("ATED", agentDetails, None)
 
       val document = Jsoup.parse(html.toString())
-      Then("The title should match - ATED clients - GOV.UK")
-      assert(document.title() === "ATED clients - GOV.UK")
+      Then("The title should match - client.summary.title - GOV.UK")
+      assert(document.title() === "client.summary.title - GOV.UK")
 
       And("I should not see the clients cancelled panel")
       assert(document.getElementById("client-cancelled-title") === null)
 
       And("The Pre Header should be the agents name - ABC Ltd.")
-      assert(document.getElementById("pre-header").text() === "this is for: Org Name")
+      assert(document.getElementById("pre-header").text() === "ated.screen-reader.name Org Name")
 
       And("The Add Client Button - should exist")
-      assert(document.getElementById("add-client-btn").text() === "Add a client")
+      assert(document.getElementById("add-client-btn").text() === "client.summary.add-client")
 
       And("The Add Client Link - should not exist")
       assert(document.getElementById("add-client-link") === null)
@@ -85,7 +82,7 @@ class noClientsNoPendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite
       val document = Jsoup.parse(html.toString())
 
       Then("I should see the clients cancelled panel")
-      assert(document.getElementById("client-cancelled-title").text === "Your authority to act for these clients has been removed:")
+      assert(document.getElementById("client-cancelled-title").text === "client.summary.client-cancelled.text")
 
       And("I should see the name of the client")
       assert(document.getElementById("client-cancelled-name-0").text === "AAA")

--- a/test/views/agent/agentSummary/pendingViewSpec.scala
+++ b/test/views/agent/agentSummary/pendingViewSpec.scala
@@ -20,7 +20,6 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FeatureSpec, GivenWhenThen}
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.{Lang, Messages}
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.FakeRequest
@@ -29,15 +28,13 @@ import uk.gov.hmrc.agentclientmandate.models._
 import uk.gov.hmrc.agentclientmandate.service.Mandates
 import uk.gov.hmrc.agentclientmandate.views
 import uk.gov.hmrc.domain.{AtedUtr, Generator}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import unit.uk.gov.hmrc.agentclientmandate.builders.AgentBuilder
 
-class pendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with GivenWhenThen{
+class pendingViewSpec extends FeatureSpec  with MockitoSugar with BeforeAndAfterEach with GivenWhenThen with ViewTestHelper {
 
   val registeredAddressDetails = RegisteredAddressDetails("123 Fake Street", "Somewhere", None, None, None, "GB")
   val agentDetails: AgentDetails = AgentBuilder.buildAgentDetails
-
-  private val mcc: MessagesControllerComponents = app.injector.instanceOf[MessagesControllerComponents]
-  implicit val messages: Messages = mcc.messagesApi.preferred(Seq(Lang.defaultLang))
 
   val mandateId = "12345678"
   val time1: DateTime = DateTime.now()
@@ -76,7 +73,6 @@ class pendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
     clientDisplayName = "client display name 5")
 
   implicit val request = FakeRequest()
-  implicit val appConfig : AppConfig = app.injector.instanceOf[AppConfig]
 
   feature("The agent can view the agent summary page when they only have pending clients") {
 
@@ -93,14 +89,14 @@ class pendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val html = views.html.agent.agentSummary.pending("ATED", Mandates(Nil, pendingMandates), agentDetails, None, "")
 
       val document = Jsoup.parse(html.toString())
-      Then("The title should match - ATED clients - GOV.UK")
-      assert(document.title() === "ATED clients - GOV.UK")
+      Then("The title should match - client.summary.title - GOV.UK")
+      assert(document.title() === "client.summary.title - GOV.UK")
 
       And("I should not see the clients cancelled panel")
       assert(document.getElementById("client-cancelled-title") === null)
       
       And("The Pending Clients tab - should exist")
-      assert(document.getElementById("pending-clients").text === "Requests (4) selected")
+      assert(document.getElementById("pending-clients").text === "client.summary.client-pending.title selected")
 
 
 
@@ -108,7 +104,7 @@ class pendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       And("The Add Client Button - should not exist")
       assert(document.getElementById("add-client-btn") === null)
       And("The Add Client Link - should exist")
-      assert(document.getElementById("add-client-link").text() === "Add a client")
+      assert(document.getElementById("add-client-link").text() === "client.summary.add-client")
     }
 
     scenario("agent visits summary page with clients cancelled in last 28 days") {
@@ -120,7 +116,7 @@ class pendingViewSpec extends FeatureSpec with GuiceOneServerPerSuite with Mocki
       val document = Jsoup.parse(html.toString())
 
       Then("I should see the clients cancelled panel")
-      assert(document.getElementById("client-cancelled-title").text === "Your authority to act for these clients has been removed:")
+      assert(document.getElementById("client-cancelled-title").text === "client.summary.client-cancelled.text")
 
       And("I should see the name of the client")
       assert(document.getElementById("client-cancelled-name-0").text === "AAA")


### PR DESCRIPTION
# DL-2125 Refactor unit tests to not use FakeApp

**Test refactor**

* Refactored tests to not make use of FakeApplication, speeding up the test execution and also preventing tests from running out memory from being continously run inside sbt.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
