### PR TITLE
DL-2057 Added internal route for client banner

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnector.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnector.scala
@@ -113,6 +113,11 @@ class AgentClientMandateConnector @Inject()(val servicesConfig: ServicesConfig,
     http.GET[HttpResponse](getUrl)
   }
 
+  def fetchMandateByClientId(clientId: String, service: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    val getUrl = s"$serviceUrl/org/${java.util.UUID.randomUUID.toString}/$mandateUri/$clientId/$service"
+    http.GET[HttpResponse](getUrl)
+  }
+
   def doesAgentHaveMissingEmail(service: String, authRetrievals: AgentAuthRetrievals)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     val AgentAuthRetrievals(arn, agentCode, _, _, _) = authRetrievals
     val authLink = s"/agent/$agentCode"

--- a/app/uk/gov/hmrc/agentclientmandate/controllers/client/ClientBannerPartialController.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/controllers/client/ClientBannerPartialController.scala
@@ -22,12 +22,11 @@ import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.controllers.auth.AuthorisedWrappers
 import uk.gov.hmrc.agentclientmandate.models.Status.{Active, Approved, Cancelled, Rejected}
 import uk.gov.hmrc.agentclientmandate.service.AgentClientMandateService
-import uk.gov.hmrc.agentclientmandate.utils.AgentClientMandateUtils
 import uk.gov.hmrc.agentclientmandate.views.html.partials.client_banner
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ClientBannerPartialController @Inject()(mcc: MessagesControllerComponents,
@@ -35,7 +34,6 @@ class ClientBannerPartialController @Inject()(mcc: MessagesControllerComponents,
                                               mandateService: AgentClientMandateService,
                                               implicit val ec: ExecutionContext,
                                               implicit val appConfig: AppConfig) extends FrontendController(mcc) with AuthorisedWrappers {
-
   def getBanner(clientId: String, service: String, returnUrl: String): Action[AnyContent] = Action.async {
     implicit request => {
       withOrgCredId(Some(service)) { clientAuthRetrievals =>
@@ -43,10 +41,14 @@ class ClientBannerPartialController @Inject()(mcc: MessagesControllerComponents,
 
         mandateService.fetchClientMandateByClient(clientId, service, clientAuthRetrievals).map {
           case Some(mandate) => mandate.currentStatus.status match {
-            case Active => Ok(client_banner(service, mandate.agentParty.name, mandateHost + routes.RemoveAgentController.view(mandate.id, returnUrl).url, "attorneyBanner--client-request-accepted", "active", "approved_active"))
-            case Approved => Ok(client_banner(service, mandate.agentParty.name, mandateHost + routes.RemoveAgentController.view(mandate.id, returnUrl).url, "attorneyBanner--client-request-requested", "approved", "approved_active"))
-            case Rejected => Ok(client_banner(service, mandate.agentParty.name, mandateHost + routes.CollectEmailController.view().url, "attorneyBanner--client-request-rejected", "rejected", "cancelled_rejected"))
-            case Cancelled => Ok(client_banner(service, mandate.agentParty.name, mandateHost + routes.CollectEmailController.view().url, "attorneyBanner--client-request-rejected", "cancelled", "cancelled_rejected"))
+            case Active => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+              + uk.gov.hmrc.agentclientmandate.controllers.client.routes.RemoveAgentController.view(mandate.id, returnUrl).url, "attorneyBanner--client-request-accepted", "active", "approved_active"))
+            case Approved => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+              + uk.gov.hmrc.agentclientmandate.controllers.client.routes.RemoveAgentController.view(mandate.id, returnUrl).url, "attorneyBanner--client-request-requested", "approved", "approved_active"))
+            case Rejected => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+              + uk.gov.hmrc.agentclientmandate.controllers.client.routes.CollectEmailController.view().url, "attorneyBanner--client-request-rejected", "rejected", "cancelled_rejected"))
+            case Cancelled => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+              + uk.gov.hmrc.agentclientmandate.controllers.client.routes.CollectEmailController.view().url, "attorneyBanner--client-request-rejected", "cancelled", "cancelled_rejected"))
           }
           case None => NotFound
         }

--- a/app/uk/gov/hmrc/agentclientmandate/controllers/internal/ClientBannerPartialInternalController.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/controllers/internal/ClientBannerPartialInternalController.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientmandate.controllers.internal
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.agentclientmandate.config.AppConfig
+import uk.gov.hmrc.agentclientmandate.controllers.auth.AuthorisedWrappers
+import uk.gov.hmrc.agentclientmandate.controllers.client.routes
+import uk.gov.hmrc.agentclientmandate.models.Status.{Active, Approved, Cancelled, Rejected}
+import uk.gov.hmrc.agentclientmandate.service.AgentClientMandateService
+import uk.gov.hmrc.agentclientmandate.views.html.partials.client_banner
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ClientBannerPartialInternalController @Inject()(mcc: MessagesControllerComponents,
+                                              val authConnector: AuthConnector,
+                                              mandateService: AgentClientMandateService,
+                                              implicit val ec: ExecutionContext,
+                                              implicit val appConfig: AppConfig) extends FrontendController(mcc) with AuthorisedWrappers {
+  def getClientBannerPartial(clientId: String, service: String, returnUrl: String): Action[AnyContent] = Action.async { implicit request =>
+    val mandateHost = appConfig.mandateFrontendHost
+
+    mandateService.fetchClientMandateByClientId(clientId, service).map {
+      case Some(mandate) => mandate.currentStatus.status match {
+        case Active => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+          + uk.gov.hmrc.agentclientmandate.controllers.client.routes.RemoveAgentController.view(mandate.id, returnUrl).url, "attorneyBanner--client-request-accepted", "active", "approved_active"))
+        case Approved => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+          + uk.gov.hmrc.agentclientmandate.controllers.client.routes.RemoveAgentController.view(mandate.id, returnUrl).url, "attorneyBanner--client-request-requested", "approved", "approved_active"))
+        case Rejected => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+          + uk.gov.hmrc.agentclientmandate.controllers.client.routes.CollectEmailController.view().url, "attorneyBanner--client-request-rejected", "rejected", "cancelled_rejected"))
+        case Cancelled => Ok(client_banner(service, mandate.agentParty.name, mandateHost
+          + uk.gov.hmrc.agentclientmandate.controllers.client.routes.CollectEmailController.view().url, "attorneyBanner--client-request-rejected", "cancelled", "cancelled_rejected"))
+      }
+      case None => NotFound
+    }
+  }
+}

--- a/app/uk/gov/hmrc/agentclientmandate/service/AgentClientMandateService.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/service/AgentClientMandateService.scala
@@ -97,6 +97,17 @@ class AgentClientMandateService @Inject()(val dataCacheService: DataCacheService
     }
   }
 
+
+  def fetchClientMandateByClientId(clientId: String, serviceName: String)
+                                (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Mandate]] = {
+    agentClientMandateConnector.fetchMandateByClientId(clientId, serviceName) map {
+      response => response.status match {
+        case OK => response.json.asOpt[Mandate]
+        case _ => None
+      }
+    }
+  }
+
   def approveMandate(mandate: Mandate, clientAuthRetrievals: ClientAuthRetrievals)
                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Mandate]] = {
     agentClientMandateConnector.approveMandate(mandate, clientAuthRetrievals) flatMap { response =>

--- a/conf/internal.routes
+++ b/conf/internal.routes
@@ -1,0 +1,3 @@
+
+# internal routes
+GET     /client/partial-banner/:clientId/:service       uk.gov.hmrc.agentclientmandate.controllers.internal.ClientBannerPartialInternalController.getClientBannerPartial(clientId: String, service: String, returnUrl: String)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,5 @@
 # Add all the application routes to the app.routes file
-
 ->          /mandate                        app.Routes
+->          /internal                       internal.Routes
 ->          /                               health.Routes
 GET         /admin/metrics                  @com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -28,7 +28,7 @@ trait MicroService {
   lazy val scoverageSettings = {
     import scoverage.ScoverageKeys
     Seq(
-      ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;app.Routes.*;prod.*;testOnlyDoNotUseInAppConf.*;uk.gov.hmrc.agentclientmandate.config.*;uk.gov.hmrc.agentclientmandate.views.*;uk.gov.hmrc.BuildInfo*;uk.gov.hmrc.agentclientmandate.viewModelsAndForms.*;uk.gov.hmrc.agentclientmandate.controllers.testOnly.*",
+      ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;app.Routes.*;internal.Routes.*;prod.*;testOnlyDoNotUseInAppConf.*;uk.gov.hmrc.agentclientmandate.config.*;uk.gov.hmrc.agentclientmandate.views.*;uk.gov.hmrc.BuildInfo*;uk.gov.hmrc.agentclientmandate.viewModelsAndForms.*;uk.gov.hmrc.agentclientmandate.controllers.testOnly.*",
       ScoverageKeys.coverageMinimum := 100,
       ScoverageKeys.coverageFailOnMinimum := true,
       ScoverageKeys.coverageHighlighting := true

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnectorSpec.scala
@@ -231,6 +231,17 @@ class AgentClientMandateConnectorSpec extends PlaySpec with GuiceOneServerPerSui
       await(response).status must be(OK)
     }
 
+    "fetch a mandate for a client by id" in new Setup {
+      val successResponse = Json.toJson(mandate)
+
+      when(mockDefaultHttpClient.GET[HttpResponse]
+        (ArgumentMatchers.any())
+        (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(HttpResponse(OK, Some(successResponse))))
+
+      val response = agentClientMandateConnector.fetchMandateByClientId("clientId", "service")
+      await(response).status must be(OK)
+    }
+
     "does an agent have a missing email" in new Setup {
       when(mockDefaultHttpClient.GET[HttpResponse]
         (ArgumentMatchers.any())

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
@@ -381,6 +381,23 @@ class AgentClientMandateServiceSpec extends PlaySpec with GuiceOneServerPerSuite
       }
     }
 
+    "fetch mandate for client id" when {
+      "returns a mandate when client party exists, is active, and for correct service" in new Setup {
+        val respJson = Json.toJson(mandateActive)
+        when(mockAgentClientMandateConnector.fetchMandateByClientId(any(), any())(any()))
+          .thenReturn(Future.successful(HttpResponse(OK, Some(respJson))))
+        val response = service.fetchClientMandateByClientId("clientId", "service")
+        await(response) must be(Some(mandateActive))
+      }
+
+      "returns None for all other" in new Setup {
+        when(mockAgentClientMandateConnector.fetchMandateByClientId(any(), any())(any()))
+          .thenReturn(Future.successful(HttpResponse(NOT_FOUND)))
+        val response = service.fetchClientMandateByClientId("clientId", "service")
+        await(response) must be(None)
+      }
+    }
+
     "check for agent missing email" must {
       "return false if agent is missing email" in new Setup {
         when(mockAgentClientMandateConnector.doesAgentHaveMissingEmail(any(), any())(any())) thenReturn Future.successful(HttpResponse(NO_CONTENT))


### PR DESCRIPTION
# DL-2057 Added internal route for client banner

**New route**

* Added an internal route for the client banner. This internal route does not do auth checks.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
