### PR TITLE
pluginRemove removal of sbt-artificatory plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val scoverageSettings = {
 val silencerVersion = "1.7.1"
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala,SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin,SbtArtifactory) ++ plugins : _*)
+  .enablePlugins(Seq(play.sbt.PlayScala,SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins : _*)
   .settings(playSettings ++ scoverageSettings : _*)
   .settings(majorVersion := 1)
   .settings(scalaSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,8 +28,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.6.0")
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
pluginRemove

**Bug fix** 

Jenkins fails to build with version 1.6.0 of the sbt-artificatory
Advised by build and deploy team that this is not required as Jenkins uses a global default

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
