### PR TITLE
DL-7834 removing residual reference to urBanner

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/config/AppConfig.scala
@@ -46,8 +46,6 @@ class AppConfig @Inject()(
     feedbackUrl + "?return=" + returnUri
   }
 
-  lazy val urBannerToggle: Boolean = loadConfig("urBanner.toggle").toBoolean
-  lazy val urBannerLink: String = loadConfig("urBanner.link")
   lazy val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
   lazy val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
   lazy val betaFeedbackUnauthenticatedUrl = s"$contactHost/contact/beta-feedback-unauthenticated"

--- a/app/uk/gov/hmrc/agentclientmandate/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/main_template.scala.html
@@ -28,7 +28,6 @@
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/main.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("jquery/jquery-ui.min.css")'/>
     <link rel="stylesheet" href='@controllers.routes.Assets.versioned("jquery/jquery-ui.structure.min.css")'/>
-    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("stylesheets/urBanner.css")'/>
     @scriptElem
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,11 +51,6 @@ tracking-consent-frontend {
 
 accessibility-statement.service-path = "/agent-client-mandate"
 
-urBanner{
-  toggle = true
-  link = "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=ATED_details_summary&utm_source=Survey_Banner&utm_medium=other&t=HMRC&id=129"
-}
-
 microservice {
   metrics {
     graphite {

--- a/test/unit/uk/gov/hmrc/agentclientmandate/builders/MockControllerSetup.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/builders/MockControllerSetup.scala
@@ -41,8 +41,6 @@ trait MockControllerSetup {
     .thenReturn("")
   when(mockAppConfig.loginPath)
     .thenReturn("gg/sign-in")
-  when(mockAppConfig.urBannerToggle)
-    .thenReturn(true)
   when(mockAppConfig.getIsoCodeTupleList)
     .thenReturn(List())
   when(mockAppConfig.addNonUkClientCorrespondenceUri(ArgumentMatchers.any()))


### PR DESCRIPTION
Removing references to urBanner that were causing console error where page was unable to load the stylesheet as it did not exist (having been removed previously)

Removed other references to urBanner that are not utilised
Checked app-config-* files as entry found in application.conf - unable to see any references

Test and ATs run successfully 