### PR TITLE
DL-12001: remove unused orgType parameter from AgentDetails model and…

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/models/AgentDetails.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/models/AgentDetails.scala
@@ -39,8 +39,7 @@ object Individual {
 }
 
 case class Organisation(organisationName: String,
-                        isAGroup: Option[Boolean] = None,
-                        organisationType: Option[String] = None)
+                        isAGroup: Option[Boolean] = None)
 
 object Organisation {
   implicit val formats: OFormat[Organisation] = Json.format[Organisation]

--- a/app/uk/gov/hmrc/agentclientmandate/service/AgentClientMandateService.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/service/AgentClientMandateService.scala
@@ -258,9 +258,7 @@ class AgentClientMandateService @Inject()(val dataCacheService: DataCacheService
     val updateData = UpdateRegistrationDetailsRequest(isAnIndividual = false,
       individual = None,
       organisation = Some(Organisation(
-        organisationName = editAgentDetails.map(_.agentName).getOrElse(cachedData.organisation.map(_.organisationName).getOrElse("")),
-        isAGroup = cachedData.organisation.flatMap(_.isAGroup),
-        organisationType = cachedData.organisation.flatMap(_.organisationType))),
+        organisationName = editAgentDetails.map(_.agentName).getOrElse(cachedData.organisation.map(_.organisationName).getOrElse("")))),
       address = editAgentDetails.map(_.address).getOrElse(cachedData.addressDetails),
       contactDetails = cachedData.contactDetails,
       isAnAgent = true,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,16 +14,6 @@
 
 include "frontend.conf"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.AuditModule` or create your own.
-# An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.agentclientmandate.ServiceBindings"
 
 appName = "agent-client-mandate-frontend"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,7 @@ private object AppDependencies {
     "uk.gov.hmrc"       %% "http-caching-client"           % "10.0.0-play-28",
     "uk.gov.hmrc"       %% "emailaddress"                  % "3.8.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.13.0-play-28",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "7.21.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "7.23.0-play-28",
     "commons-codec"     %  "commons-codec"                 % "1.16.0"
   )
 
@@ -24,15 +24,14 @@ private object AppDependencies {
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test: Seq[ModuleID] = Seq(
-        "org.scalatestplus.play"       %% "scalatestplus-play"     % "5.1.0"    % scope,
-        "org.jsoup"                    %  "jsoup"                  % "1.16.1"   % scope,
-        "org.scalatestplus"            %% "scalacheck-1-17"        % "3.2.17.0" % scope,
-        "org.mockito"                  %  "mockito-core"           % "5.5.0"    % scope,
-        "org.scalatestplus"            %% "scalatestplus-mockito"  % "1.0.0-M2" % scope,
-        "com.typesafe.play"            %% "play-test"              % current    % scope,
-        "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.35.1"   % scope,
-        "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.15.2"   % scope,
-        "uk.gov.hmrc"                  %% "bootstrap-test-play-28" % "7.22.0"   % scope
+      "uk.gov.hmrc"                  %% "bootstrap-test-play-28" % "7.22.0"   % scope,
+      "org.scalatestplus.play"       %% "scalatestplus-play"     % "5.1.0"    % scope,
+      "org.jsoup"                    %  "jsoup"                  % "1.16.2"   % scope,
+      "org.scalatestplus"            %% "scalacheck-1-17"        % "3.2.17.0" % scope,
+      "org.mockito"                  %  "mockito-core"           % "5.6.0"    % scope,
+      "org.scalatestplus"            %% "scalatestplus-mockito"  % "1.0.0-M2" % scope,
+      "com.github.tomakehurst"       %  "wiremock-jre8"          % "2.35.1"   % scope,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.15.3"   % scope
       )
     }.test
   }

--- a/test/unit/uk/gov/hmrc/agentclientmandate/builders/AgentBuilder.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/builders/AgentBuilder.scala
@@ -24,7 +24,7 @@ object AgentBuilder {
     val registeredAddressDetails = RegisteredAddressDetails("address1", "address2", None, None, None, "FR")
     val contactDetails = EtmpContactDetails()
     AgentDetails("safeId", isAnIndividual = false, None,
-      Some(Organisation("Org Name", Some(true), Some("org_type"))),
+      Some(Organisation("Org Name", Some(true))),
       registeredAddressDetails, contactDetails, Some(Identification("IdNumber", "issuingCountry", "FR")))
   }
 
@@ -32,7 +32,7 @@ object AgentBuilder {
     val registeredAddressDetails = RegisteredAddressDetails("address1", "address2", None, None, None, "GB")
     val contactDetails = EtmpContactDetails()
     AgentDetails("safeId", isAnIndividual = false, None,
-      Some(Organisation("Org Name", Some(true), Some("org_type"))),
+      Some(Organisation("Org Name", Some(true))),
       registeredAddressDetails, contactDetails, None)
   }
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/BusinessCustomerConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/BusinessCustomerConnectorSpec.scala
@@ -57,7 +57,7 @@ class BusinessCustomerConnectorSpec extends PlaySpec  with MockitoSugar with Bef
       "business customer service responds with a HttpResponse OK" in new Setup {
 
 
-        val updateRegDetails = UpdateRegistrationDetailsRequest(isAnIndividual = false,None,Some(Organisation("Org Name",Some(true),Some("org_type"))),
+        val updateRegDetails = UpdateRegistrationDetailsRequest(isAnIndividual = false,None,Some(Organisation("Org Name",Some(true))),
           RegisteredAddressDetails("address1","address2",None,None,None,"FR"),
           EtmpContactDetails(None,None,None,None),isAnAgent = true,isAGroup = true,Some(Identification("idnumber","FR","issuingInstitution")))
         when(mockDefaultHttpClient.POST[UpdateRegistrationDetailsRequest, HttpResponse]
@@ -74,7 +74,7 @@ class BusinessCustomerConnectorSpec extends PlaySpec  with MockitoSugar with Bef
       "business customer service responds with a HttpResponse INTERNAL_SERVER_ERROR" in new Setup {
 
 
-        val updateRegDetails = UpdateRegistrationDetailsRequest(isAnIndividual = false,None,Some(Organisation("Org Name",Some(true),Some("org_type"))),
+        val updateRegDetails = UpdateRegistrationDetailsRequest(isAnIndividual = false,None,Some(Organisation("Org Name",Some(true))),
           RegisteredAddressDetails("address1","address2",None,None,None,"FR"),
           EtmpContactDetails(None,None,None,None),isAnAgent = true,isAGroup = true,Some(Identification("idnumber","FR","issuingInstitution")))
         when(mockDefaultHttpClient.POST[UpdateRegistrationDetailsRequest, HttpResponse]

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateAddressDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateAddressDetailsControllerSpec.scala
@@ -44,7 +44,7 @@ class UpdateAddressDetailsControllerSpec extends PlaySpec with MockitoSugar with
   val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
   val agentDetails: AgentDetails = AgentBuilder.buildAgentDetails
   val updateRegDetails: Option[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
-    Some(Organisation("Org name", Some(true), Some("org_type"))), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
+    Some(Organisation("Org name", Some(true))), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
     EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, None))
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateOcrDetailsControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/UpdateOcrDetailsControllerSpec.scala
@@ -44,7 +44,7 @@ class UpdateOcrDetailsControllerSpec extends PlaySpec with MockitoSugar with Bef
   val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
   val agentDetails: AgentDetails = AgentBuilder.buildAgentDetails
   val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
-    Some(Organisation("Org name", Some(true), Some("org_type"))),
+    Some(Organisation("Org name", Some(true))),
     RegisteredAddressDetails("address1", "address2", None, None, None, "FR"), EtmpContactDetails(None, None, None, None),
     isAnAgent = true, isAGroup = true,
     identification = Some(Identification("IdNumber", "issuingCountry", "FR"))))

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
@@ -476,7 +476,7 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
           EditAgentAddressDetails("Org name", RegisteredAddressDetails("address1", "address2", countryCode = "FR"))
         val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
         val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
-          Some(Organisation("Org name", Some(true), Some("org_type"))), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
+          Some(Organisation("Org name")), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
           EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, None))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
           .thenReturn (Future.successful(cachedData))
@@ -484,6 +484,7 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
         when(mockDataCacheService.clearCache()(any(), any())).thenReturn(Future.successful(HttpResponse(OK, "")))
         val response: Future[Option[UpdateRegistrationDetailsRequest]] =
           service.updateRegisteredDetails(agentAuthRetrievals = testAgentAuthRetrievals,  editAgentDetails = Some(editAgentAddress))
+
         await(response) must be(updateRegDetails)
       }
 
@@ -491,7 +492,7 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
         val nonUkiOcrChanges: Identification = Identification("idnumber", "FR", "issuingInstitution")
         val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
         val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
-          Some(Organisation("Org Name", Some(true), Some("org_type"))), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
+          Some(Organisation("Org Name")), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
           EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, Some(Identification("idnumber", "FR", "issuingInstitution"))))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
           .thenReturn (Future.successful(cachedData))
@@ -507,7 +508,7 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
       "none of the inputs are passed" in new Setup {
         val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
         val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
-          Some(Organisation("Org Name", Some(true), Some("org_type"))), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
+          Some(Organisation("Org Name")), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
           EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, None))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
           .thenReturn (Future.successful(cachedData))

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
@@ -475,7 +475,7 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
         val editAgentAddress: EditAgentAddressDetails =
           EditAgentAddressDetails("Org name", RegisteredAddressDetails("address1", "address2", countryCode = "FR"))
         val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
-        val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
+        val updatedDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
           Some(Organisation("Org name")), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
           EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, None))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
@@ -485,13 +485,13 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
         val response: Future[Option[UpdateRegistrationDetailsRequest]] =
           service.updateRegisteredDetails(agentAuthRetrievals = testAgentAuthRetrievals,  editAgentDetails = Some(editAgentAddress))
 
-        await(response) must be(updateRegDetails)
+        await(response) must be(updatedDetails)
       }
 
       "ocr details are changed and saved" in new Setup {
         val nonUkiOcrChanges: Identification = Identification("idnumber", "FR", "issuingInstitution")
         val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
-        val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
+        val updatedDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
           Some(Organisation("Org Name")), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
           EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, Some(Identification("idnumber", "FR", "issuingInstitution"))))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
@@ -500,14 +500,14 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
         when(mockDataCacheService.clearCache()(any(), any())).thenReturn(Future.successful(HttpResponse(OK, "")))
         val response: Future[Option[UpdateRegistrationDetailsRequest]] =
           service.updateRegisteredDetails(agentAuthRetrievals = testAgentAuthRetrievals, editNonUKIdDetails = Some(nonUkiOcrChanges))
-        await(response) must be(updateRegDetails)
+        await(response) must be(updatedDetails)
       }
     }
 
     "fail to update the agent business details" when {
       "none of the inputs are passed" in new Setup {
         val cachedData: Some[AgentDetails] = Some(AgentBuilder.buildAgentDetails)
-        val updateRegDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
+        val updatedDetails: Some[UpdateRegistrationDetailsRequest] = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
           Some(Organisation("Org Name")), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
           EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, None))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
@@ -515,15 +515,11 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
         when(mockBusinessCustomerConnector.updateRegistrationDetails(any(), any(), any())(any(), any())) thenReturn Future.successful(HttpResponse(OK, ""))
         when(mockDataCacheService.clearCache()(any(), any())).thenReturn(Future.successful(HttpResponse(OK, "")))
         val response: Future[Option[UpdateRegistrationDetailsRequest]] = service.updateRegisteredDetails(agentAuthRetrievals = testAgentAuthRetrievals)
-        await(response) must be(updateRegDetails)
+        await(response) must be(updatedDetails)
       }
 
       "no data found in cache" in new Setup {
         val nonUkiOcrChanges: Identification = Identification("idnumber", "FR", "issuingInstitution")
-//        val cachedData = Some(AgentBuilder.buildAgentDetails)
-//        val updateRegDetails = Some(UpdateRegistrationDetailsRequest(isAnIndividual = false, None,
-//          Some(Organisation("Org Name", Some(true), Some("org_type"))), RegisteredAddressDetails("address1", "address2", None, None, None, "FR"),
-//          EtmpContactDetails(None, None, None, None), isAnAgent = true, isAGroup = true, Some(Identification("idnumber", "FR", "issuingInstitution"))))
         when(mockDataCacheService.fetchAndGetFormData[AgentDetails](ArgumentMatchers.eq(service.agentDetailsFormId))(any(), any(), any()))
           .thenReturn (Future.successful(None))
         when(mockBusinessCustomerConnector.updateRegistrationDetails(any(), any(), any())(any(), any())) thenReturn Future.successful(HttpResponse(OK, ""))

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/DataCacheServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/DataCacheServiceSpec.scala
@@ -96,7 +96,12 @@ class DataCacheServiceSpec extends PlaySpec  with MockitoSugar with BeforeAndAft
 
         when(mockDefaultHttpClient.GET[CacheMap](any(), any(), any())
           (any(), any(), any()))
-          .thenReturn(Future.successful(CacheMap("test", Map(formIdNotExist -> Json.toJson(formData)))))
+          .thenReturn(Future.successful(CacheMap("test", Map(formIdNotExist -> Json.parse(
+            """{
+              |   "name":"some-data",
+              |   "other": false
+              |}
+              |""".stripMargin)))))
 
         await(testDataCacheService.fetchAndGetFormData[FormData](formIdNotExist)) must be(Some(formData))
       }


### PR DESCRIPTION
… send only organisation name for updateDetails to match schema

# DL-12001

**Bug fix** 

Removed unused parameter from AgentDetails model, reduced the number of fields sent as part of the updateDetails call in order to pass schema validation

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
