### PR TITLE
DL-14604, Changes to fix None expection using connector

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnector.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnector.scala
@@ -119,12 +119,12 @@ class AgentClientMandateConnector @Inject()(val servicesConfig: ServicesConfig,
     http.get(url"$getUrl").execute[HttpResponse]
   }
 
-  def updateAgentMissingEmail(emailAddress: String, agentAuthRetrievals: AgentAuthRetrievals, service: String)
-                             (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+  def updateAgentMissingEmail(emailAddress: Option[String], agentAuthRetrievals: AgentAuthRetrievals, service: String)
+                             (implicit hc: HeaderCarrier, ec: ExecutionContext): Option[Future[HttpResponse]]= emailAddress map { email =>
     val authLink = agentAuthRetrievals.mandateConnectorUriNoAuthId
     val arn = agentAuthRetrievals.agentRef
 
-    val jsonData = Json.toJson(emailAddress)
+    val jsonData = Json.toJson(email)
     val postUrl = s"$serviceUrl$authLink/$mandateUri/updateAgentEmail/$arn/$service"
     http.post(url"$postUrl").withBody(jsonData).execute[HttpResponse]
   }

--- a/app/uk/gov/hmrc/agentclientmandate/controllers/agent/AgentMissingEmailController.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/controllers/agent/AgentMissingEmailController.scala
@@ -49,9 +49,7 @@ class AgentMissingEmailController @Inject()(
       agentMissingEmailForm.bindFromRequest().fold(
         formWithError => Future.successful(BadRequest(templateAgentMissingEmail(formWithError, service))),
         data => {
-          if (data.email.isDefined) {
-            agentClientMandateService.updateAgentMissingEmail(data.email.get, authRetrievals, service)
-          }
+          agentClientMandateService.updateAgentMissingEmail(data.email, authRetrievals, service)
           Future.successful(Redirect(routes.AgentSummaryController.view()))
         }
       )

--- a/app/uk/gov/hmrc/agentclientmandate/service/AgentClientMandateService.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/service/AgentClientMandateService.scala
@@ -219,7 +219,7 @@ class AgentClientMandateService @Inject()(val dataCacheService: DataCacheService
     }
   }
 
-  def updateAgentMissingEmail(emailAddress: String, agentAuthRetrievals: AgentAuthRetrievals, service: String)
+  def updateAgentMissingEmail(emailAddress: Option[String], agentAuthRetrievals: AgentAuthRetrievals, service: String)
                              (implicit hc: HeaderCarrier, ec: ExecutionContext): Unit = {
     agentClientMandateConnector.updateAgentMissingEmail(emailAddress, agentAuthRetrievals, service)
   }

--- a/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/connectors/AgentClientMandateConnectorSpec.scala
@@ -220,7 +220,7 @@ class AgentClientMandateConnectorSpec extends PlaySpec  with MockitoSugar with B
     "update an agents email address" in new Setup {
       when(execute[HttpResponse]).thenReturn(Future.successful(HttpResponse(OK, "")))
 
-      val response = await(agentClientMandateConnector.updateAgentMissingEmail("test@mail.com", testAgentAuthRetrievals, "ated"))
+      val response = await(agentClientMandateConnector.updateAgentMissingEmail(Some("test@mail.com"), testAgentAuthRetrievals, "ated").get)
       response.status must be(OK)
     }
 

--- a/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/services/AgentClientMandateServiceSpec.scala
@@ -466,7 +466,7 @@ class AgentClientMandateServiceSpec extends PlaySpec with MockitoSugar with Befo
 
     "update agent email" must {
       "update an agents missing email address" in new Setup {
-        service.updateAgentMissingEmail("test@mail.com", testAgentAuthRetrievals, "ated")
+        service.updateAgentMissingEmail(Some("test@mail.com"), testAgentAuthRetrievals, "ated")
       }
     }
 


### PR DESCRIPTION
# DL-14604

**Bug fix - None.get Exception from ACM 

When agent doesn't have email, on login the receive notification page give option to choose yes or no. Choosing no has the bug which is fixed. Now on selecting no, user should be able to continue further.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
