### PR TITLE
DL-16789: Dynamic content change on screen: create new guidance page

### DIFF
--- a/app/uk/gov/hmrc/agentclientmandate/controllers/agent/BeforeRegisteringClientController.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/controllers/agent/BeforeRegisteringClientController.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientmandate.controllers.agent
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.agentclientmandate.config.AppConfig
+import uk.gov.hmrc.agentclientmandate.controllers.auth.AuthorisedWrappers
+import uk.gov.hmrc.agentclientmandate.utils.{ACMFeatureSwitches, ControllerPageIdConstants, MandateConstants}
+import uk.gov.hmrc.agentclientmandate.views
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class BeforeRegisteringClientController @Inject()(
+                                       mcc: MessagesControllerComponents,
+                                       val authConnector: AuthConnector,
+                                       implicit val appConfig: AppConfig,
+                                       templateBeforeRegisteringClient: views.html.agent.beforeRegisteringClient,
+                                        ACMFeatureSwitches: ACMFeatureSwitches
+                                       ) extends FrontendController(mcc) with AuthorisedWrappers with MandateConstants {
+
+  val controllerId: String = ControllerPageIdConstants.beforeRegisteringClientControllerId
+
+  def view(service: String, callingPage: String): Action[AnyContent] = Action { implicit request =>
+    if (ACMFeatureSwitches.registeringClientContentUpdate.enabled) {
+      Ok(templateBeforeRegisteringClient(callingPage, service, getBackLink(callingPage)))
+    } else {
+      Redirect(uk.gov.hmrc.agentclientmandate.controllers.agent.routes.ClientPermissionController.view(callingPage))
+    }
+  }
+
+  def submit(): Action[AnyContent] = Action {
+    Redirect(uk.gov.hmrc.agentclientmandate.controllers.agent.routes.ClientPermissionController.view(controllerId))
+  }
+
+  private def getBackLink(callingPage: String): String
+  = {
+    val paySAPageId: String = ControllerPageIdConstants.paySAQuestionControllerId
+
+    callingPage match {
+      case `paySAPageId` => routes.PaySAQuestionController.view().url
+      case _ => routes.NRLQuestionController.view().url
+    }
+  }
+
+
+  }
+

--- a/app/uk/gov/hmrc/agentclientmandate/controllers/agent/ClientPermissionController.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/controllers/agent/ClientPermissionController.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.connectors.AtedSubscriptionFrontendConnector
 import uk.gov.hmrc.agentclientmandate.controllers.auth.AuthorisedWrappers
 import uk.gov.hmrc.agentclientmandate.service.DataCacheService
-import uk.gov.hmrc.agentclientmandate.utils.{ControllerPageIdConstants, MandateConstants}
+import uk.gov.hmrc.agentclientmandate.utils.{ACMFeatureSwitches, ControllerPageIdConstants, MandateConstants}
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.ClientPermission
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.ClientPermissionForm._
 import uk.gov.hmrc.agentclientmandate.views
@@ -40,6 +40,7 @@ class ClientPermissionController @Inject()(
                                             val authConnector: AuthConnector,
                                             implicit val ec: ExecutionContext,
                                             implicit val appConfig: AppConfig,
+                                            ACMFeatureSwitches: ACMFeatureSwitches,
                                             templateClientPermission: views.html.agent.clientPermission
                                           ) extends FrontendController(mcc) with AuthorisedWrappers with MandateConstants {
 
@@ -81,11 +82,14 @@ class ClientPermissionController @Inject()(
   }
 
   private def getBackLink(callingPage: String) = {
-    val pageId: String = ControllerPageIdConstants.paySAQuestionControllerId
+    val PaySAPageId: String = ControllerPageIdConstants.paySAQuestionControllerId
+    val beforeRegisteringClientControllerPageId: String = ControllerPageIdConstants.beforeRegisteringClientControllerId
 
     callingPage match {
-      case `pageId` => Some(routes.PaySAQuestionController.view().url)
-      case _        => Some(routes.NRLQuestionController.view().url)
+      case `PaySAPageId` => Some(routes.PaySAQuestionController.view().url)
+      case `beforeRegisteringClientControllerPageId` if ACMFeatureSwitches.registeringClientContentUpdate.enabled =>
+        Some(routes.BeforeRegisteringClientController.view(callingPage).url)
+      case _ => Some(routes.NRLQuestionController.view().url)
     }
   }
 }

--- a/app/uk/gov/hmrc/agentclientmandate/controllers/agent/PaySAQuestionController.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/controllers/agent/PaySAQuestionController.scala
@@ -20,7 +20,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.agentclientmandate.config.AppConfig
 import uk.gov.hmrc.agentclientmandate.controllers.auth.AuthorisedWrappers
 import uk.gov.hmrc.agentclientmandate.service.DataCacheService
-import uk.gov.hmrc.agentclientmandate.utils.{ControllerPageIdConstants, MandateConstants}
+import uk.gov.hmrc.agentclientmandate.utils.{ACMFeatureSwitches, ControllerPageIdConstants, MandateConstants}
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.PaySAQuestion
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.PaySAQuestion._
 import uk.gov.hmrc.agentclientmandate.views
@@ -37,6 +37,7 @@ class PaySAQuestionController @Inject()(
                                          implicit val ec: ExecutionContext,
                                          implicit val appConfig: AppConfig,
                                          val mcc: MessagesControllerComponents,
+                                         ACMFeatureSwitches: ACMFeatureSwitches,
                                          templatePaySAQuestion: views.html.agent.paySAQuestion
                                        ) extends FrontendController(mcc) with AuthorisedWrappers with MandateConstants {
 
@@ -65,7 +66,11 @@ class PaySAQuestionController @Inject()(
             val result = if (data.paySA.getOrElse(false)) {
               Redirect(routes.MandateDetailsController.view(controllerId))
             } else {
-              Redirect(routes.ClientPermissionController.view(controllerId))
+              if (ACMFeatureSwitches.registeringClientContentUpdate.enabled) {
+                Redirect(routes.BeforeRegisteringClientController.view(controllerId))
+              } else {
+                Redirect(routes.ClientPermissionController.view(controllerId))
+              }
             }
             Future.successful(result)
           }

--- a/app/uk/gov/hmrc/agentclientmandate/utils/ControllerPageIdConstants.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/utils/ControllerPageIdConstants.scala
@@ -20,4 +20,6 @@ object ControllerPageIdConstants {
   val paySAQuestionControllerId = "paySA"
   val overseasClientQuestionControllerId = "overseas"
   val nrlQuestionControllerId: String = "nrl"
+  val beforeRegisteringClientControllerId: String = "beforeRegisteringClient"
+
 }

--- a/app/uk/gov/hmrc/agentclientmandate/utils/FeatureSwitch.scala
+++ b/app/uk/gov/hmrc/agentclientmandate/utils/FeatureSwitch.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.agentclientmandate.utils
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import play.api.libs.json.{Json, OFormat}
 
+import javax.inject.Inject
 import scala.util.Try
 
 case class FeatureSwitch(name: String, enabled: Boolean)
@@ -66,5 +67,13 @@ object MandateFeatureSwitches {
     case "registering_client_content_update" => Some(registeringClientContentUpdate)
     case _ => None
   }
+
+}
+
+class ACMFeatureSwitches @Inject() (implicit val servicesConfig: ServicesConfig) {
+
+  def singleService: FeatureSwitch = MandateFeatureSwitches.singleService
+
+  def registeringClientContentUpdate: FeatureSwitch = MandateFeatureSwitches.registeringClientContentUpdate
 
 }

--- a/app/uk/gov/hmrc/agentclientmandate/views/agent/beforeRegisteringClient.scala.html
+++ b/app/uk/gov/hmrc/agentclientmandate/views/agent/beforeRegisteringClient.scala.html
@@ -1,0 +1,73 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentclientmandate.config.AppConfig
+@import uk.gov.hmrc.agentclientmandate.controllers.agent.routes
+@import uk.gov.hmrc.agentclientmandate.views.ViewUtils.titleBuilder
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.agentclientmandate.views.html._
+
+@this(main_template:main_template,
+        formHelper: FormWithCSRF,
+        govukButton: GovukButton,
+        govukBackLink: GovukBackLink)
+
+@(callingPage: String, service: String, backLink: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@backLinkHtml = {
+    @if(backLink.nonEmpty) {
+        @govukBackLink(BackLink(
+            href = backLink,
+            content = Text("Back")
+        ))
+    }
+}
+
+@main_template(title = titleBuilder(messages("agent.before-registering-client.title")),
+               beforeContent = Some(backLinkHtml)) {
+
+    <header>
+        <h1 class="govuk-heading-xl">
+            <span class="govuk-caption-xl">
+                <span class="govuk-visually-hidden">
+                    @messages("ated.screen-reader.section")
+                </span>
+                @messages("agent.add-a-client.sub-header")
+            </span>
+            @messages("agent.before-registering-client.header")
+        </h1>
+    </header>
+
+    <div class="govuk-body" id="info">
+        <ul class="govuk-list govuk-list--bullet">
+            <li id="bullet-1">each client you register must complete an
+                <a class="govuk-link" href="https://www.gov.uk/government/publications/annual-tax-on-enveloped-dwellings-ated-1">
+                    ATED 1
+                </a>
+                form. If you already have an ATED 1 for a client, they do not need to complete another.</li>
+            <li id="bullet-2">@messages("agent.before-registering-client.bullet-2")</li>
+            <li id="bullet-3">@messages("agent.before-registering-client.bullet-3")</li>
+        </ul>
+    </div>
+
+    @formHelper(action = routes.BeforeRegisteringClientController.submit()) {
+        @govukButton(Button(
+            content = Text(messages("continue-button")),
+            inputType = Some("submit"),
+            attributes = Map("id" -> "submit")
+        ))
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -61,6 +61,9 @@ POST    /agent/nrl-question            uk.gov.hmrc.agentclientmandate.controller
 GET     /agent/paySA-question            uk.gov.hmrc.agentclientmandate.controllers.agent.PaySAQuestionController.view(service = "ated")
 POST    /agent/paySA-question            uk.gov.hmrc.agentclientmandate.controllers.agent.PaySAQuestionController.submit(service = "ated")
 
+GET     /agent/before-registering-client/:callingPage   uk.gov.hmrc.agentclientmandate.controllers.agent.BeforeRegisteringClientController.view(service = "ated", callingPage: String)
+POST    /agent/before-registering-client/   uk.gov.hmrc.agentclientmandate.controllers.agent.BeforeRegisteringClientController.submit()
+
 GET     /agent/client-permission/:callingPage   uk.gov.hmrc.agentclientmandate.controllers.agent.ClientPermissionController.view(service = "ated", callingPage: String)
 POST    /agent/client-permission/:callingPage   uk.gov.hmrc.agentclientmandate.controllers.agent.ClientPermissionController.submit(service = "ated", callingPage: String)
 

--- a/conf/messages
+++ b/conf/messages
@@ -237,6 +237,13 @@ agent.paySA-question.header = Does your client pay tax in the UK through Self As
 agent.paySA-question.error.general.paySA = There is a problem with the do you pay Self Assessment question
 agent.paySA-question.paySA.not-selected.error = Select yes if your client pays tax in the UK through Self Assessment
 
+##### AGENT BEFORE REGISTERING CLIENT PAGE
+
+agent.before-registering-client.title = Before registering your client
+agent.before-registering-client.header = Before registering your client
+agent.before-registering-client.bullet-2 = once you have registered them, send their ATED 1 to HMRC and keep a copy for your records.
+agent.before-registering-client.bullet-3 = form 64-8 does not cover ATED or ATED-related Capital Gains Tax.
+
 ##### AGENT CLIENT PERMISSION PAGE
 
 agent.client-permission.title = Do you have permission to register on behalf of your client?

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/BeforeRegisteringClientControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/BeforeRegisteringClientControllerSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.uk.gov.hmrc.agentclientmandate.controllers.agent
+
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.http.Status.OK
+import play.api.test.Helpers._
+import uk.gov.hmrc.agentclientmandate.controllers.agent.BeforeRegisteringClientController
+import uk.gov.hmrc.agentclientmandate.utils.{ACMFeatureSwitches, FeatureSwitch}
+import uk.gov.hmrc.auth.core.AuthConnector
+import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder, MockControllerSetup, SessionBuilder}
+
+import java.util.UUID
+
+class BeforeRegisteringClientControllerSpec extends PlaySpec with MockitoSugar with GuiceOneServerPerSuite with MockControllerSetup {
+
+  val mockAuthConnector: AuthConnector = mock[AuthConnector]
+  val mockFeatureSwitch: ACMFeatureSwitches = mock[ACMFeatureSwitches]
+  val service: String = "ATED"
+  val injectedViewInstanceBeforeRegisteringClient: uk.gov.hmrc.agentclientmandate.views.html.agent.beforeRegisteringClient = app.injector.instanceOf[uk.gov.hmrc.agentclientmandate.views.html.agent.beforeRegisteringClient]
+
+  val mockBeforeRegisteringClientController: BeforeRegisteringClientController = new BeforeRegisteringClientController(
+    stubbedMessagesControllerComponents,
+    mockAuthConnector,
+    mockAppConfig,
+    injectedViewInstanceBeforeRegisteringClient,
+    mockFeatureSwitch
+  )
+
+  lazy val userId = s"user-${UUID.randomUUID}"
+
+  def setUpMocks(): Unit = {
+    AuthenticatedWrapperBuilder.mockAuthorisedAgent(mockAuthConnector)
+  }
+
+  def setUpFeatureSwitchMock(value: Boolean): Unit = {
+    when(mockFeatureSwitch.registeringClientContentUpdate)
+      .thenReturn(FeatureSwitch("registeringClientContentUpdate", value))
+  }
+
+  "BeforeRegisteringClientController" should {
+
+    "return OK when the view is accessed and feature flag is set to true" in {
+      setUpMocks()
+      setUpFeatureSwitchMock(true)
+      val result = mockBeforeRegisteringClientController.view(service, "callingPage").apply(SessionBuilder.buildRequestWithSession(userId))
+
+      status(result) mustBe OK
+    }
+
+    "redirect to ClientPermissionController when the view is accessed and feature flag is set to false" in {
+      setUpMocks()
+      setUpFeatureSwitchMock(false)
+      val result = mockBeforeRegisteringClientController.view(service, "callingPage").apply(SessionBuilder.buildRequestWithSession(userId))
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(uk.gov.hmrc.agentclientmandate.controllers.agent.routes.ClientPermissionController.view("callingPage").url)
+    }
+
+    "redirect to ClientPermissionController when the submit action is called" in {
+      setUpMocks()
+      setUpFeatureSwitchMock(true)
+      val result = mockBeforeRegisteringClientController.submit().apply(SessionBuilder.buildRequestWithSession(userId))
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(uk.gov.hmrc.agentclientmandate.controllers.agent.routes.ClientPermissionController.view("beforeRegisteringClient").url)
+    }
+
+    "have the correct back link based on caller id" in {
+      setUpMocks()
+      setUpFeatureSwitchMock(true)
+      val result = mockBeforeRegisteringClientController.view(service, "paySA").apply(SessionBuilder.buildRequestWithSession(userId))
+
+      status(result) mustBe OK
+      contentAsString(result) must include(uk.gov.hmrc.agentclientmandate.controllers.agent.routes.PaySAQuestionController.view().url)
+
+    }
+  }
+}

--- a/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/PaySAQuestionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/agentclientmandate/controllers/agent/PaySAQuestionControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package unit.uk.gov.hmrc.agentclientmandate.controllers.agent
 
-import java.util.UUID
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -29,18 +28,21 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientmandate.controllers.agent.PaySAQuestionController
 import uk.gov.hmrc.agentclientmandate.service.DataCacheService
+import uk.gov.hmrc.agentclientmandate.utils.{ACMFeatureSwitches, FeatureSwitch}
 import uk.gov.hmrc.agentclientmandate.viewModelsAndForms.PaySAQuestion
 import uk.gov.hmrc.agentclientmandate.views
 import uk.gov.hmrc.agentclientmandate.views.html.agent.paySAQuestion
 import uk.gov.hmrc.auth.core.AuthConnector
 import unit.uk.gov.hmrc.agentclientmandate.builders.{AuthenticatedWrapperBuilder, MockControllerSetup, SessionBuilder}
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class PaySAQuestionControllerSpec extends PlaySpec with BeforeAndAfterEach with MockitoSugar with MockControllerSetup with GuiceOneServerPerSuite {
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
+  val mockFeatureSwitch: ACMFeatureSwitches = mock[ACMFeatureSwitches]
   val service: String = "ATED"
   val mockDataCacheService: DataCacheService = mock[DataCacheService]
   val injectedViewInstancePaySAQuestion: paySAQuestion = app.injector.instanceOf[views.html.agent.paySAQuestion]
@@ -52,8 +54,14 @@ class PaySAQuestionControllerSpec extends PlaySpec with BeforeAndAfterEach with 
       implicitly,
       mockAppConfig,
       stubbedMessagesControllerComponents,
+      mockFeatureSwitch,
       injectedViewInstancePaySAQuestion
     )
+
+    def setUpFeatureSwitchMock(value: Boolean): Unit = {
+      when(mockFeatureSwitch.registeringClientContentUpdate)
+        .thenReturn(FeatureSwitch("registeringClientContentUpdate", value))
+    }
 
     def viewWithUnAuthenticatedAgent(test: Future[Result] => Any): Unit = {
 
@@ -162,10 +170,22 @@ class PaySAQuestionControllerSpec extends PlaySpec with BeforeAndAfterEach with 
 
     "redirect agent to 'client permission' page" when {
       "valid form is submitted and NO is selected as client pays self-assessment" in new Setup {
+        setUpFeatureSwitchMock(false)
         val fakeRequest: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest().withMethod("POST").withFormUrlEncodedBody("paySA" -> "false")
         submitWithAuthorisedAgent(fakeRequest) { result =>
           status(result) must be(SEE_OTHER)
           redirectLocation(result).get must include(s"/agent/client-permission/paySA")
+        }
+      }
+    }
+
+    "redirect agent to 'before registering client' page" when {
+      "valid form is submitted and NO is selected as client pays self-assessment and feature flag is on" in new Setup {
+        setUpFeatureSwitchMock(true)
+        val fakeRequest: FakeRequest[AnyContentAsFormUrlEncoded] = FakeRequest().withMethod("POST").withFormUrlEncodedBody("paySA" -> "false")
+        submitWithAuthorisedAgent(fakeRequest) { result =>
+          status(result) must be(SEE_OTHER)
+          redirectLocation(result).get must include(s"/agent/before-registering-client/paySA")
         }
       }
     }

--- a/test/views/agent/beforeRegisteringClientViewSpec.scala
+++ b/test/views/agent/beforeRegisteringClientViewSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.agent
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.agentclientmandate.config.AppConfig
+import uk.gov.hmrc.agentclientmandate.views.html.agent.beforeRegisteringClient
+
+
+class beforeRegisteringClientViewSpec extends AnyWordSpec with MockitoSugar with ViewTestHelper with GuiceOneServerPerSuite{
+
+  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  override implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(request)
+  val injectedViewInstanceBeforeRegisteringClient: beforeRegisteringClient = app.injector.instanceOf[beforeRegisteringClient]
+
+  val view: Html = injectedViewInstanceBeforeRegisteringClient("callingPage", "ATED", "backLink")
+  val doc: Document = Jsoup.parse(view.toString)
+
+  "The before registering client view" when {
+    "rendered" must {
+
+      "have the correct page title" in {
+        doc.title mustBe ("Before registering your client - Submit and view your ATED returns - GOV.UK")
+      }
+
+      "have the correct header" in {
+        doc.select("h1").text() mustBe ("This section is: Add a client Before registering your client")
+      }
+
+      "have the correct information text" in {
+        doc.getElementById("bullet-1").html() mustBe "each client you register must complete an <a class=\"govuk-link\" href=\"https://www.gov.uk/government/publications/annual-tax-on-enveloped-dwellings-ated-1\"> ATED 1 </a> form. If you already have an ATED 1 for a client, they do not need to complete another."
+        doc.getElementById("bullet-2").html() mustBe "once you have registered them, send their ATED 1 to HMRC and keep a copy for your records."
+        doc.getElementById("bullet-3").html() mustBe "form 64-8 does not cover ATED or ATED-related Capital Gains Tax."
+      }
+
+      "have the correct link to the ATED 1 form" in {
+        doc.getElementById("bullet-1").select("a").attr("href") mustBe "https://www.gov.uk/government/publications/annual-tax-on-enveloped-dwellings-ated-1"
+      }
+
+      "have a back link when backLink is defined" in {
+        val viewWithBackLink: Html = injectedViewInstanceBeforeRegisteringClient("callingPage", "ATED", "/back-link")
+        val docWithBackLink: Document = Jsoup.parse(viewWithBackLink.toString)
+
+        val backLink = docWithBackLink.select("a.govuk-back-link")
+        backLink.attr("href") mustBe "/back-link"
+        backLink.text() mustBe "Back"
+      }
+
+      "have a continue button with correct attributes" in {
+        val button = doc.select("button#submit")
+        button.text() mustBe "Continue"
+        button.attr("type") mustBe "submit"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Created new controller and corresponding page. Included tests for page and controller.
- Redirected nrl-question page and pay SA page to new controller
- added back link to new controller from client permission controller, and added tests for these